### PR TITLE
Migrate legacy GitHub Gist embeds to native Shiki code blocks using a Remark plugin

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -15,6 +15,7 @@ import {
 } from "@shikijs/transformers";
 import { transformerFileName } from "./src/utils/transformers/fileName";
 import { remarkGifToVideo } from "./src/utils/transformers/gifToVideo.js";
+import { remarkGist } from "./src/utils/transformers/remarkGist.js";
 import { SITE } from "./src/config";
 
 // https://astro.build/config
@@ -50,6 +51,7 @@ export default defineConfig({
       remarkToc,
       [remarkCollapse, { test: "Table of contents" }],
       remarkGifToVideo,
+      remarkGist,
     ],
     shikiConfig: {
       // For more themes, visit https://shiki.style/themes

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "prettier-plugin-astro": "^0.14.1",
     "prettier-plugin-tailwindcss": "^0.7.2",
     "typescript": "^5.9.3",
-    "typescript-eslint": "^8.51.0"
+    "typescript-eslint": "^8.51.0",
+    "unist-util-visit": "^5.1.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,6 +105,9 @@ importers:
       typescript-eslint:
         specifier: ^8.51.0
         version: 8.51.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      unist-util-visit:
+        specifier: ^5.1.0
+        version: 5.1.0
 
 packages:
 
@@ -3353,14 +3356,11 @@ packages:
   unist-util-visit-children@3.0.0:
     resolution: {integrity: sha512-RgmdTfSBOg04sdPcpTSD1jzoNBjt9a80/ZCzp5cI9n1qPzLZWF9YdvWGN2zmTumP1HWhXKdUWexjy/Wy/lJ7tA==}
 
-  unist-util-visit-parents@6.0.1:
-    resolution: {integrity: sha512-L/PqWzfTP9lzzEa6CKs0k2nARxTdZduw3zyh8d2NVBnsyvHjSX4TWse388YrrQKbvI8w20fGjGlhgT96WwKykw==}
-
   unist-util-visit-parents@6.0.2:
     resolution: {integrity: sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==}
 
-  unist-util-visit@5.0.0:
-    resolution: {integrity: sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==}
+  unist-util-visit@5.1.0:
+    resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
 
   unstorage@1.17.3:
     resolution: {integrity: sha512-i+JYyy0DoKmQ3FximTHbGadmIYb8JEpq7lxUjnjeB702bCPum0vzo6oy5Mfu0lpqISw7hCyMW2yj4nWC8bqJ3Q==}
@@ -3854,7 +3854,7 @@ snapshots:
       smol-toml: 1.6.0
       unified: 11.0.5
       unist-util-remove-position: 5.0.0
-      unist-util-visit: 5.0.0
+      unist-util-visit: 5.1.0
       unist-util-visit-parents: 6.0.2
       vfile: 6.0.3
     transitivePeerDependencies:
@@ -5112,7 +5112,7 @@ snapshots:
       tsconfck: 3.1.6(typescript@5.9.3)
       ultrahtml: 1.6.0
       unifont: 0.6.0
-      unist-util-visit: 5.0.0
+      unist-util-visit: 5.1.0
       unstorage: 1.17.3
       vfile: 6.0.3
       vite: 6.4.1(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.7.1)
@@ -5758,7 +5758,7 @@ snapshots:
       mdast-util-to-hast: 13.2.0
       parse5: 7.2.1
       unist-util-position: 5.0.0
-      unist-util-visit: 5.0.0
+      unist-util-visit: 5.1.0
       vfile: 6.0.3
       web-namespaces: 2.0.1
       zwitch: 2.0.4
@@ -6030,7 +6030,7 @@ snapshots:
     dependencies:
       '@types/mdast': 4.0.4
       '@types/unist': 3.0.3
-      unist-util-visit: 5.0.0
+      unist-util-visit: 5.1.0
 
   mdast-util-find-and-replace@3.0.2:
     dependencies:
@@ -6131,7 +6131,7 @@ snapshots:
       micromark-util-sanitize-uri: 2.0.1
       trim-lines: 3.0.1
       unist-util-position: 5.0.0
-      unist-util-visit: 5.0.0
+      unist-util-visit: 5.1.0
       vfile: 6.0.3
 
   mdast-util-to-markdown@2.1.2:
@@ -6143,7 +6143,7 @@ snapshots:
       mdast-util-to-string: 4.0.0
       micromark-util-classify-character: 2.0.1
       micromark-util-decode-string: 2.0.1
-      unist-util-visit: 5.0.0
+      unist-util-visit: 5.1.0
       zwitch: 2.0.4
 
   mdast-util-to-string@1.1.0: {}
@@ -6160,7 +6160,7 @@ snapshots:
       github-slugger: 2.0.0
       mdast-util-to-string: 4.0.0
       unist-util-is: 6.0.0
-      unist-util-visit: 5.0.0
+      unist-util-visit: 5.1.0
 
   mdn-data@2.0.28: {}
 
@@ -6674,7 +6674,7 @@ snapshots:
       retext: 9.0.0
       retext-smartypants: 6.2.0
       unified: 11.0.5
-      unist-util-visit: 5.0.0
+      unist-util-visit: 5.1.0
 
   remark-stringify@11.0.0:
     dependencies:
@@ -6709,7 +6709,7 @@ snapshots:
     dependencies:
       '@types/nlcst': 2.0.3
       nlcst-to-string: 4.0.0
-      unist-util-visit: 5.0.0
+      unist-util-visit: 5.1.0
 
   retext-stringify@4.0.0:
     dependencies:
@@ -7051,7 +7051,7 @@ snapshots:
   unist-util-remove-position@5.0.0:
     dependencies:
       '@types/unist': 3.0.3
-      unist-util-visit: 5.0.0
+      unist-util-visit: 5.1.0
 
   unist-util-stringify-position@4.0.0:
     dependencies:
@@ -7061,21 +7061,16 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
 
-  unist-util-visit-parents@6.0.1:
-    dependencies:
-      '@types/unist': 3.0.3
-      unist-util-is: 6.0.0
-
   unist-util-visit-parents@6.0.2:
     dependencies:
       '@types/unist': 3.0.3
       unist-util-is: 6.0.0
 
-  unist-util-visit@5.0.0:
+  unist-util-visit@5.1.0:
     dependencies:
       '@types/unist': 3.0.3
       unist-util-is: 6.0.0
-      unist-util-visit-parents: 6.0.1
+      unist-util-visit-parents: 6.0.2
 
   unstorage@1.17.3:
     dependencies:

--- a/src/utils/transformers/remarkGist.js
+++ b/src/utils/transformers/remarkGist.js
@@ -1,0 +1,105 @@
+import { visit } from "unist-util-visit";
+
+/**
+ * Remark plugin to transform embedded GitHub Gist scripts into standard Markdown code blocks.
+ * Uses GitHub's public CDN to bypass standard API rate limits and token requirements.
+ */
+export function remarkGist() {
+  return async tree => {
+    const nodes = [];
+
+    // 1. Find all HTML nodes containing a Gist script
+    visit(tree, "html", node => {
+      if (node.value && node.value.includes("gist.github.com")) {
+        nodes.push(node);
+      }
+    });
+
+    if (nodes.length === 0) return;
+
+    // 2. Process them asynchronously at build time
+    await Promise.all(
+      nodes.map(async node => {
+        // Extract Username and Gist ID from the script tag
+        // Matches: <script src="https://gist.github.com/PatilShreyas/42a4281f433103ef2d2803b270fc6edd.js"></script>
+        const match = node.value.match(
+          /gist\.github\.com\/([a-zA-Z0-9_-]+)\/([a-f0-9]+)\.js/
+        );
+
+        if (match && match[1] && match[2]) {
+          const username = match[1];
+          const gistId = match[2];
+
+          try {
+            // STEP A: Fetch the public embed JSON (No strict API rate limits here)
+            const jsonRes = await fetch(
+              `https://gist.github.com/${username}/${gistId}.json`
+            );
+
+            if (!jsonRes.ok) {
+              // eslint-disable-next-line no-console
+              console.warn(
+                `[remarkGist] Failed to fetch JSON for Gist ${gistId}`
+              );
+              return;
+            }
+
+            const gistData = await jsonRes.json();
+
+            if (gistData.files && gistData.files.length > 0) {
+              // Get the first file in the Gist
+              const filename = gistData.files[0];
+
+              // Extract the extension to map to Shiki syntax highlighting
+              const ext = filename.split(".").pop().toLowerCase();
+
+              // Map common extensions to Shiki language identifiers
+              const langMap = {
+                kt: "kotlin",
+                java: "java",
+                js: "javascript",
+                ts: "typescript",
+                py: "python",
+                yml: "yaml",
+                md: "markdown",
+                json: "json",
+                xml: "xml",
+                html: "html",
+                css: "css",
+                sh: "bash",
+              };
+              const lang = langMap[ext] || ext || "text";
+
+              // STEP B: Fetch the raw code directly from GitHub's CDN (No API rate limits)
+              const rawUrl = `https://gist.githubusercontent.com/${username}/${gistId}/raw/${encodeURIComponent(
+                filename
+              )}`;
+
+              const rawRes = await fetch(rawUrl);
+              if (!rawRes.ok) {
+                // eslint-disable-next-line no-console
+                console.warn(
+                  `[remarkGist] Failed to fetch raw code for Gist ${gistId}`
+                );
+                return;
+              }
+
+              const rawContent = await rawRes.text();
+
+              // 3. Mutate the AST HTML node into a standard code block for Astro/Shiki
+              node.type = "code";
+              node.lang = lang;
+              node.value = rawContent.trim();
+            }
+          } catch (error) {
+            // eslint-disable-next-line no-console
+            console.error(
+              `[remarkGist] Exception processing Gist ${gistId}:`,
+              error
+            );
+          }
+        }
+      })
+    );
+  };
+}


### PR DESCRIPTION
This change implements a custom Remark plugin to automatically migrate legacy GitHub Gist embed scripts (`<script src="...gist.github.com..."></script>`) into standard markdown code blocks during the Astro build process. It fetches the raw code directly from GitHub's CDN to avoid API rate limits, detects the language using the file extension, and converts the HTML AST node into a Markdown code block, allowing Astro's Shiki renderer to syntax highlight the snippets.

---
*PR created automatically by Jules for task [16837134042922463217](https://jules.google.com/task/16837134042922463217) started by @PatilShreyas*