### PR TITLE
Fix Content Security Policy errors for external resources

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -5,7 +5,7 @@
   Referrer-Policy: strict-origin-when-cross-origin
   Permissions-Policy: geolocation=(), microphone=(), camera=(), payment=()
   Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
-  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' https://www.googletagmanager.com https://www.google-analytics.com https://gist.github.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self'; connect-src 'self' https://www.google-analytics.com https://analytics.google.com; frame-src https://gist.github.com https://www.youtube.com https://www.youtube-nocookie.com https://player.vimeo.com; object-src 'none'; base-uri 'self'; form-action 'self'
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.googletagmanager.com https://www.google-analytics.com https://gist.github.com https://cdn.jsdelivr.net https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self'; connect-src 'self' https://www.google-analytics.com https://analytics.google.com https://stats.g.doubleclick.net; frame-src https://gist.github.com https://www.youtube.com https://www.youtube-nocookie.com https://player.vimeo.com; object-src 'none'; base-uri 'self'; form-action 'self'; media-src 'self' https://github.com https://raw.githubusercontent.com https://*.github.com
   Cache-Control: public, max-age=3600, stale-while-revalidate=86400
 
 # Hashed assets from Astro (JS, CSS, optimized images) — content-addressed, cache forever


### PR DESCRIPTION
Resolves the reported Content Security Policy errors occurring when the site is published on Cloudflare. Added missing sources to `./public/_headers` to allow Google Analytics, Cloudflare Insights, Pagefind WebAssembly, and GitHub media to load successfully.

---
*PR created automatically by Jules for task [4539845935632480823](https://jules.google.com/task/4539845935632480823) started by @PatilShreyas*