### PR TITLE
🔒 Fix reverse tabnabbing vulnerability

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -34,6 +34,7 @@ const paginatedRecentPosts = recentPosts.slice(0, SITE.postPerPage);
         class="inline-block"
         aria-label="rss feed"
         title="RSS Feed"
+        rel="noopener noreferrer"
       >
         <IconRss
           width={20}


### PR DESCRIPTION
🎯 **What:** The `target="_blank"` attribute was missing `rel="noopener noreferrer"` in the RSS feed link.
⚠️ **Risk:** It opens the possibility to reverse tabnabbing attacks, a security vulnerability.
🛡️ **Solution:** Added `rel="noopener noreferrer"` attribute to the anchor element to mitigate this issue.

---
*PR created automatically by Jules for task [12018174786296946097](https://jules.google.com/task/12018174786296946097) started by @PatilShreyas*