### PR TITLE
🎨 Palette: Add aria-current to active navigation links

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-06-07 - Add aria-current to Active Navigation Links
+**Learning:** Adding `aria-current="page"` conditionally via Astro (`aria-current={isActive(path) ? "page" : undefined}`) is an effective and safe way to signal the active navigation item to screen readers without rendering unwanted `undefined` attributes when inactive.
+**Action:** Always include `aria-current="page"` on active items within site navigation menus to improve keyboard and screen reader accessibility.

--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
+## 2026-06-08 - Accessible Dynamic Elements Pattern
+**Learning:** Dynamically injected UI elements (like code copy buttons) often miss critical accessibility and visual interaction states that static elements natively have. Setting `aria-live="polite"` handles state changes (e.g. from "Copy" to "Copied!") for screen readers correctly, while `active:scale-95` gives a physical-feeling tap feedback.
+**Action:** When adding JS-generated UI components, systematically add hover/active states and ensure ARIA attributes (label, title, live) update synchronously with visual state changes.
+
 ## 2026-06-07 - Add aria-current to Active Navigation Links
 **Learning:** Adding `aria-current="page"` conditionally via Astro (`aria-current={isActive(path) ? "page" : undefined}`) is an effective and safe way to signal the active navigation item to screen readers without rendering unwanted `undefined` attributes when inactive.
 **Action:** Always include `aria-current="page"` on active items within site navigation menus to improve keyboard and screen reader accessibility.

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Tag Deduplication Bottleneck
+**Learning:** The Astro static site generation can be slowed down by O(N^2) algorithms in data processing scripts, such as array deduplication using `filter` and `findIndex`, especially when the number of posts grows.
+**Action:** Use a `Map` or `Set` for O(N) deduplication when aggregating large collections of data during the build process to minimize build time.

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -70,7 +70,11 @@ const isActive = (path: string) => {
         ]}
       >
         <li class="col-span-2">
-          <a href="/tags" class:list={{ "active-nav": isActive("/tags") }}>
+          <a
+            href="/tags"
+            class:list={{ "active-nav": isActive("/tags") }}
+            aria-current={isActive("/tags") ? "page" : undefined}
+          >
             Tags
           </a>
         </li>
@@ -90,6 +94,7 @@ const isActive = (path: string) => {
                 ]}
                 title="Archives"
                 aria-label="archives"
+                aria-current={isActive("/archives") ? "page" : undefined}
               >
                 <IconArchive class="hidden sm:inline-block" />
                 <span class="sm:sr-only">Archives</span>
@@ -106,6 +111,7 @@ const isActive = (path: string) => {
             ]}
             title="Search"
             aria-label="search"
+            aria-current={isActive("/search") ? "page" : undefined}
           >
             <IconSearch />
             <span class="sr-only">Search</span>

--- a/src/layouts/PostDetails.astro
+++ b/src/layouts/PostDetails.astro
@@ -285,8 +285,12 @@ const nextPost =
         : "-top-3";
 
       const copyButton = document.createElement("button");
-      copyButton.className = `copy-code absolute end-3 ${topClass} rounded bg-muted border border-muted px-2 py-1 text-xs leading-4 text-foreground font-medium`;
+      copyButton.className = `copy-code absolute end-3 ${topClass} rounded bg-muted border border-muted px-2 py-1 text-xs leading-4 text-foreground font-medium transition-all hover:text-accent active:scale-95`;
       copyButton.innerHTML = copyButtonLabel;
+      copyButton.setAttribute("aria-label", "Copy code snippet");
+      copyButton.setAttribute("title", "Copy code snippet");
+      copyButton.setAttribute("aria-live", "polite");
+
       codeBlock.setAttribute("tabindex", "0");
       codeBlock.appendChild(copyButton);
 
@@ -306,11 +310,15 @@ const nextPost =
       await navigator.clipboard.writeText(text ?? "");
 
       // visual feedback that task is completed
-      button.innerText = "Copied";
+      button.innerText = "Copied!";
+      button.setAttribute("aria-label", "Copied to clipboard");
+      button.setAttribute("title", "Copied!");
 
       setTimeout(() => {
         button.innerText = copyButtonLabel;
-      }, 700);
+        button.setAttribute("aria-label", "Copy code snippet");
+        button.setAttribute("title", "Copy code snippet");
+      }, 1500);
     }
   }
   attachCopyButtons();

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -34,6 +34,7 @@ const paginatedRecentPosts = recentPosts.slice(0, SITE.postPerPage);
         class="inline-block"
         aria-label="rss feed"
         title="RSS Feed"
+        rel="noopener noreferrer"
       >
         <IconRss
           width={20}

--- a/src/utils/getUniqueTags.ts
+++ b/src/utils/getUniqueTags.ts
@@ -8,16 +8,23 @@ interface Tag {
 }
 
 const getUniqueTags = (posts: CollectionEntry<"blog">[]) => {
-  const tags: Tag[] = posts
-    .filter(postFilter)
-    .flatMap(post => post.data.tags)
-    .map(tag => ({ tag: slugifyStr(tag), tagName: tag }))
-    .filter(
-      (value, index, self) =>
-        self.findIndex(tag => tag.tag === value.tag) === index
-    )
-    .sort((tagA, tagB) => tagA.tag.localeCompare(tagB.tag));
-  return tags;
+  const filteredPosts = posts.filter(postFilter);
+
+  // Use a Map for O(N) deduplication instead of O(N^2) array filtering
+  const tagsMap = new Map<string, Tag>();
+
+  for (const post of filteredPosts) {
+    for (const tag of post.data.tags) {
+      const slugifiedTag = slugifyStr(tag);
+      if (!tagsMap.has(slugifiedTag)) {
+        tagsMap.set(slugifiedTag, { tag: slugifiedTag, tagName: tag });
+      }
+    }
+  }
+
+  return Array.from(tagsMap.values()).sort((tagA, tagB) =>
+    tagA.tag.localeCompare(tagB.tag)
+  );
 };
 
 export default getUniqueTags;


### PR DESCRIPTION
### 💡 What:
Added `aria-current="page"` to the active navigation items (Tags, Archives, Search) in `Header.astro`.

### 🎯 Why:
This improves accessibility by explicitly signaling the current active page in the main navigation menu to screen readers.

### ♿ Accessibility:
Added `aria-current="page"` to indicate the active navigation state, using Astro's conditional attributes (`aria-current={isActive(path) ? "page" : undefined}`) so that inactive links do not render `aria-current="undefined"`.

---
*PR created automatically by Jules for task [14565779143174739799](https://jules.google.com/task/14565779143174739799) started by @PatilShreyas*