### PR TITLE
🎨 Palette: [UX improvement] Descriptive tooltips and dynamic aria-labels on toggles

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2026-06-08 - Accessible Dynamic Elements Pattern
 **Learning:** Dynamically injected UI elements (like code copy buttons) often miss critical accessibility and visual interaction states that static elements natively have. Setting `aria-live="polite"` handles state changes (e.g. from "Copy" to "Copied!") for screen readers correctly, while `active:scale-95` gives a physical-feeling tap feedback.
 **Action:** When adding JS-generated UI components, systematically add hover/active states and ensure ARIA attributes (label, title, live) update synchronously with visual state changes.
+
+## 2026-06-09 - Descriptive Action Tooltips on Toggles
+**Learning:** For toggle buttons (like theme switchers), providing an `aria-label` or `title` that purely states the current state (e.g. "dark" or "auto") isn't fully informative to users hovering or using screen readers.
+**Action:** Use action-oriented labels like "Switch to dark theme" so the user knows exactly what will happen when they click it. Keep these attributes dynamic so they always reflect the next intended state.

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -117,8 +117,8 @@ const isActive = (path: string) => {
               <button
                 id="theme-btn"
                 class="focus-outline relative size-12 p-4 sm:size-8 hover:[&>svg]:stroke-accent"
-                title="Toggles light & dark"
-                aria-label="auto"
+                title="Switch theme"
+                aria-label="Switch theme"
                 aria-live="polite"
               >
                 <IconMoon class="absolute top-[50%] left-[50%] -translate-[50%] scale-100 rotate-0 transition-all dark:scale-0 dark:-rotate-90" />

--- a/src/layouts/PostDetails.astro
+++ b/src/layouts/PostDetails.astro
@@ -334,16 +334,16 @@ const nextPost =
       lightbox = document.createElement("div");
       lightbox.id = "lightbox";
       lightbox.innerHTML = `
-        <button class="lightbox-close" aria-label="Close">
+        <button class="lightbox-close" aria-label="Close" title="Close">
           <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>
         </button>
         <img id="lightbox-img" src="" alt="Full view" />
         <div class="lightbox-controls">
-          <button class="lightbox-btn zoom-out" disabled aria-label="Zoom Out">
+          <button class="lightbox-btn zoom-out" disabled aria-label="Zoom Out" title="Zoom Out">
             <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="5" y1="12" x2="19" y2="12"></line></svg>
           </button>
           <span class="lightbox-zoom-val">100%</span>
-          <button class="lightbox-btn zoom-in" aria-label="Zoom In">
+          <button class="lightbox-btn zoom-in" aria-label="Zoom In" title="Zoom In">
             <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="5" x2="12" y2="19"></line><line x1="5" y1="12" x2="19" y2="12"></line></svg>
           </button>
         </div>

--- a/src/scripts/theme.ts
+++ b/src/scripts/theme.ts
@@ -34,7 +34,13 @@ function setPreference(): void {
 function reflectPreference(): void {
   document.firstElementChild?.setAttribute("data-theme", themeValue);
 
-  document.querySelector("#theme-btn")?.setAttribute("aria-label", themeValue);
+  const toggleBtn = document.querySelector("#theme-btn");
+  if (toggleBtn) {
+    const nextTheme = themeValue === "light" ? "dark" : "light";
+    const label = `Switch to ${nextTheme} theme`;
+    toggleBtn.setAttribute("aria-label", label);
+    toggleBtn.setAttribute("title", label);
+  }
 
   // Set the background color in <meta theme-color ... />
   // We use values from SITE config to avoid expensive getComputedStyle calls


### PR DESCRIPTION
* 💡 What: Updated the theme switch toggle to use dynamic `aria-label` and `title` properties (e.g., "Switch to light theme" rather than just "dark" or "auto") and added `title` tooltips to icon-only lightbox controls (Close, Zoom Out, Zoom In). Documented this learning in the Palette journal.
* 🎯 Why: Icon-only buttons and toggle switches lacking clear, action-oriented descriptions make UI navigation confusing for both visual users (no hover tooltips) and screen reader users (not knowing the intended action).
* 📸 Before/After: N/A visual change (only tooltips).
* ♿ Accessibility: Improved screen reader announcements for the theme toggle (dynamic) and added native browser tooltips for icon-only lightbox buttons, making interaction paths much clearer.

---
*PR created automatically by Jules for task [9696020165064014932](https://jules.google.com/task/9696020165064014932) started by @PatilShreyas*