### PR TITLE
🎨 Palette: Add `aria-current` to active navigation links

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,6 @@
 ## 2026-06-09 - Descriptive Action Tooltips on Toggles
 **Learning:** For toggle buttons (like theme switchers), providing an `aria-label` or `title` that purely states the current state (e.g. "dark" or "auto") isn't fully informative to users hovering or using screen readers.
 **Action:** Use action-oriented labels like "Switch to dark theme" so the user knows exactly what will happen when they click it. Keep these attributes dynamic so they always reflect the next intended state.
+## 2026-06-10 - Active Page Navigation Accessibility
+**Learning:** Adding active visual styles to navigation links without an underlying semantic indicator leaves screen reader users unaware of the current page context within the navigation.
+**Action:** When a navigation item is highlighted to denote the current active page, conditionally add `aria-current="page"` to the link element to explicitly communicate this state to assistive technologies.

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -70,7 +70,11 @@ const isActive = (path: string) => {
         ]}
       >
         <li class="col-span-2">
-          <a href="/tags" class:list={{ "active-nav": isActive("/tags") }}>
+          <a
+            href="/tags"
+            class:list={{ "active-nav": isActive("/tags") }}
+            aria-current={isActive("/tags") ? "page" : undefined}
+          >
             Tags
           </a>
         </li>
@@ -90,6 +94,7 @@ const isActive = (path: string) => {
                 ]}
                 title="Archives"
                 aria-label="archives"
+                aria-current={isActive("/archives") ? "page" : undefined}
               >
                 <IconArchive class="hidden sm:inline-block" />
                 <span class="sm:sr-only">Archives</span>
@@ -106,6 +111,7 @@ const isActive = (path: string) => {
             ]}
             title="Search"
             aria-label="search"
+            aria-current={isActive("/search") ? "page" : undefined}
           >
             <IconSearch />
             <span class="sr-only">Search</span>


### PR DESCRIPTION
💡 What: Added the `aria-current="page"` attribute conditionally to navigation links (`Tags`, `Archives`, and `Search`) when they correspond to the currently active page.
🎯 Why: While sighted users can see visual cues (like an underline or color change) indicating the active page, screen reader users miss this context without a semantic HTML indicator.
📸 Before/After: Visuals remain exactly the same.
♿ Accessibility: The addition of `aria-current="page"` ensures that screen readers properly announce the current active section to users as they navigate through the header menu.

---
*PR created automatically by Jules for task [14304056158479081054](https://jules.google.com/task/14304056158479081054) started by @PatilShreyas*