### PR TITLE
⚡ Bolt: [performance improvement] Remove redundant `new Date()` wrappers

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2024-05-24 - Tag Deduplication Bottleneck
 **Learning:** The Astro static site generation can be slowed down by O(N^2) algorithms in data processing scripts, such as array deduplication using `filter` and `findIndex`, especially when the number of posts grows.
 **Action:** Use a `Map` or `Set` for O(N) deduplication when aggregating large collections of data during the build process to minimize build time.
+
+## 2024-06-11 - Astro Zod Collections Redundant Dates
+**Learning:** In Astro v5 content collections, Zod schemas that define a field with `z.date()` output a native JavaScript `Date` object directly. The codebase was unnecessarily wrapping these properties like `pubDatetime` in an extra `new Date(data.pubDatetime)` call before performing sorting, filtering, or processing in components, utils and RSS generation.
+**Action:** When filtering, mapping, or sorting Astro content collections containing Zod parsed `Date` objects, directly use `.getTime()` or assignment without passing the field to the `new Date()` constructor to avoid unnecessary allocations in tight loops.

--- a/src/pages/archives/index.astro
+++ b/src/pages/archives/index.astro
@@ -62,12 +62,8 @@ const months = [
                     {monthGroup
                       .sort(
                         (a, b) =>
-                          Math.floor(
-                            new Date(b.data.pubDatetime).getTime() / 1000
-                          ) -
-                          Math.floor(
-                            new Date(a.data.pubDatetime).getTime() / 1000
-                          )
+                          Math.floor(b.data.pubDatetime.getTime() / 1000) -
+                          Math.floor(a.data.pubDatetime.getTime() / 1000)
                       )
                       .map(data => (
                         <Card {...data} />

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -16,7 +16,7 @@ export async function GET() {
       link: getPath(id, filePath),
       title: data.title,
       description: data.description,
-      pubDate: new Date(data.modDatetime ?? data.pubDatetime),
+      pubDate: data.modDatetime ?? data.pubDatetime,
       customData: [
         `<author>${SITE.author}</author>`,
         ...data.tags.map(tag => `<category>${tag}</category>`),

--- a/src/utils/getSortedPosts.ts
+++ b/src/utils/getSortedPosts.ts
@@ -7,11 +7,9 @@ const getSortedPosts = (posts: CollectionEntry<"blog">[]) => {
     .sort(
       (a, b) =>
         Math.floor(
-          new Date(b.data.modDatetime ?? b.data.pubDatetime).getTime() / 1000
+          (b.data.modDatetime ?? b.data.pubDatetime).getTime() / 1000
         ) -
-        Math.floor(
-          new Date(a.data.modDatetime ?? a.data.pubDatetime).getTime() / 1000
-        )
+        Math.floor((a.data.modDatetime ?? a.data.pubDatetime).getTime() / 1000)
     );
 };
 

--- a/src/utils/postFilter.ts
+++ b/src/utils/postFilter.ts
@@ -3,8 +3,7 @@ import { SITE } from "@/config";
 
 const postFilter = ({ data }: CollectionEntry<"blog">) => {
   const isPublishTimePassed =
-    Date.now() >
-    new Date(data.pubDatetime).getTime() - SITE.scheduledPostMargin;
+    Date.now() > data.pubDatetime.getTime() - SITE.scheduledPostMargin;
   return !data.draft && (import.meta.env.DEV || isPublishTimePassed);
 };
 


### PR DESCRIPTION
💡 **What:** Removed redundant `new Date()` wrappers around `pubDatetime` and `modDatetime` variables across several files: `src/utils/postFilter.ts`, `src/utils/getSortedPosts.ts`, `src/pages/rss.xml.ts`, and `src/pages/archives/index.astro`.

🎯 **Why:** Astro's content collection framework with Zod correctly parses these fields as native `Date` objects. By wrapping these objects inside another `new Date()` constructor in highly trafficked iterators (like `filter` and `sort` mapped over all posts), we create unnecessary object allocations and trigger more frequent garbage collection.

📊 **Impact:** Reduces object allocations and garbage collection cycles when querying, rendering, sorting, filtering posts, and generating RSS feeds. Memory consumption should drop slightly during builds, making page processing marginally faster.

🔬 **Measurement:** This can be verified by noting a slight reduction in memory usage and time taken specifically in Astro build rendering iterations over the post collections. Building the site locally (`pnpm run build`) verifies correctness.

---
*PR created automatically by Jules for task [17465000387276286344](https://jules.google.com/task/17465000387276286344) started by @PatilShreyas*