### PR TITLE
🎨 Palette: Add accessible active state to navigation and hide decorative icons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2026-06-09 - Descriptive Action Tooltips on Toggles
 **Learning:** For toggle buttons (like theme switchers), providing an `aria-label` or `title` that purely states the current state (e.g. "dark" or "auto") isn't fully informative to users hovering or using screen readers.
 **Action:** Use action-oriented labels like "Switch to dark theme" so the user knows exactly what will happen when they click it. Keep these attributes dynamic so they always reflect the next intended state.
+
+## 2026-06-11 - Accessible Active States in Navigation
+**Learning:** Adding a visual indicator for the active navigation item (like an underline) is not enough for screen reader users. They need a programmatic way to know which page they are currently on. Additionally, icons within interactive elements that already have text alternatives (e.g., `aria-label` or visible text) can create redundant noise for screen readers.
+**Action:** Use `aria-current="page"` on navigation links that represent the current page. Always add `aria-hidden="true"` to decorative icons inside interactive elements to keep the screen reader output clean and focused on the action.

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -43,6 +43,7 @@ const isActive = (path: string) => {
     <a
       href="/"
       class="absolute py-1 text-xl leading-8 font-semibold whitespace-nowrap sm:static sm:my-auto sm:text-2xl sm:leading-none"
+      aria-current={currentPath === "/" ? "page" : undefined}
     >
       {SITE.title}
     </a>
@@ -70,12 +71,12 @@ const isActive = (path: string) => {
         ]}
       >
         <li class="col-span-2">
-          <a href="/tags" class:list={{ "active-nav": isActive("/tags") }}>
+          <a href="/tags" class:list={{ "active-nav": isActive("/tags") }} aria-current={isActive("/tags") ? "page" : undefined}>
             Tags
           </a>
         </li>
         <li class="col-span-2">
-          <a href="https://shreyaspatil.dev"> About </a>
+          <a href="https://shreyaspatil.dev" aria-current={isActive("https://shreyaspatil.dev") ? "page" : undefined}> About </a>
         </li>
         {
           SITE.showArchives && (
@@ -90,8 +91,9 @@ const isActive = (path: string) => {
                 ]}
                 title="Archives"
                 aria-label="archives"
+                aria-current={isActive("/archives") ? "page" : undefined}
               >
-                <IconArchive class="hidden sm:inline-block" />
+                <IconArchive class="hidden sm:inline-block" aria-hidden="true" />
                 <span class="sm:sr-only">Archives</span>
               </LinkButton>
             </li>
@@ -106,8 +108,9 @@ const isActive = (path: string) => {
             ]}
             title="Search"
             aria-label="search"
+            aria-current={isActive("/search") ? "page" : undefined}
           >
-            <IconSearch />
+            <IconSearch aria-hidden="true" />
             <span class="sr-only">Search</span>
           </LinkButton>
         </li>
@@ -121,8 +124,8 @@ const isActive = (path: string) => {
                 aria-label="Switch theme"
                 aria-live="polite"
               >
-                <IconMoon class="absolute top-[50%] left-[50%] -translate-[50%] scale-100 rotate-0 transition-all dark:scale-0 dark:-rotate-90" />
-                <IconSunHigh class="absolute top-[50%] left-[50%] -translate-[50%] scale-0 rotate-90 transition-all dark:scale-100 dark:rotate-0" />
+                <IconMoon aria-hidden="true" class="absolute top-[50%] left-[50%] -translate-[50%] scale-100 rotate-0 transition-all dark:scale-0 dark:-rotate-90" />
+                <IconSunHigh aria-hidden="true" class="absolute top-[50%] left-[50%] -translate-[50%] scale-0 rotate-90 transition-all dark:scale-100 dark:rotate-0" />
               </button>
             </li>
           )


### PR DESCRIPTION
💡 **What:**
- Added `aria-current="page"` to the active navigation links (`Home`, `Tags`, `About`, `Archives`, `Search`) in the header.
- Added `aria-hidden="true"` to decorative icons inside interactive elements (`IconArchive`, `IconSearch`, `IconMoon`, `IconSunHigh`) in the header.

🎯 **Why:**
- To improve accessibility for screen reader users by providing a programmatic way to identify the current active page in the navigation menu.
- To reduce redundant auditory noise for screen reader users by hiding decorative icons that are accompanied by visual text alternatives or labels.

📸 **Before/After:**
- **Before:** Active navigation links were visually distinct (e.g., underlined) but screen readers could not programmatically identify the current page. Decorative icons were read aloud, adding unnecessary noise.
- **After:** Screen readers now announce the current page when navigating the menu. Decorative icons are ignored, making the experience cleaner and more focused.

♿ **Accessibility:**
- Ensures screen reader users have the same context as visual users regarding the current page in the navigation menu.
- Improves the overall auditory experience by removing redundant icon announcements.

---
*PR created automatically by Jules for task [5795994779131416621](https://jules.google.com/task/5795994779131416621) started by @PatilShreyas*