### PR TITLE
🎨 Palette: Add aria-current to header navigation

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,6 @@
 ## 2026-06-09 - Descriptive Action Tooltips on Toggles
 **Learning:** For toggle buttons (like theme switchers), providing an `aria-label` or `title` that purely states the current state (e.g. "dark" or "auto") isn't fully informative to users hovering or using screen readers.
 **Action:** Use action-oriented labels like "Switch to dark theme" so the user knows exactly what will happen when they click it. Keep these attributes dynamic so they always reflect the next intended state.
+## 2024-05-23 - [Header Navigation Accessibility]
+**Learning:** Header navigation links were missing aria-current attribute for screen readers to identify active page.
+**Action:** Add aria-current="page" dynamically based on the active path.

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -43,6 +43,7 @@ const isActive = (path: string) => {
     <a
       href="/"
       class="absolute py-1 text-xl leading-8 font-semibold whitespace-nowrap sm:static sm:my-auto sm:text-2xl sm:leading-none"
+      aria-current={pathname === "/" ? "page" : undefined}
     >
       {SITE.title}
     </a>
@@ -70,7 +71,11 @@ const isActive = (path: string) => {
         ]}
       >
         <li class="col-span-2">
-          <a href="/tags" class:list={{ "active-nav": isActive("/tags") }}>
+          <a
+            href="/tags"
+            class:list={{ "active-nav": isActive("/tags") }}
+            aria-current={isActive("/tags") ? "page" : undefined}
+          >
             Tags
           </a>
         </li>
@@ -90,6 +95,7 @@ const isActive = (path: string) => {
                 ]}
                 title="Archives"
                 aria-label="archives"
+                aria-current={isActive("/archives") ? "page" : undefined}
               >
                 <IconArchive class="hidden sm:inline-block" />
                 <span class="sm:sr-only">Archives</span>
@@ -106,6 +112,7 @@ const isActive = (path: string) => {
             ]}
             title="Search"
             aria-label="search"
+            aria-current={isActive("/search") ? "page" : undefined}
           >
             <IconSearch />
             <span class="sr-only">Search</span>


### PR DESCRIPTION
💡 **What:** Added the `aria-current="page"` HTML attribute to the main header navigation links conditionally based on the current active path.

🎯 **Why:** To improve accessibility. It communicates to assistive technologies (like screen readers) which page is currently active, providing clear context.

📸 **Before/After:** Not applicable (visually unchanged, only HTML attribute change).

♿ **Accessibility:** Added standard ARIA roles for current active item state to header navigation links.

---
*PR created automatically by Jules for task [14469227392670555765](https://jules.google.com/task/14469227392670555765) started by @PatilShreyas*