### PR TITLE
⚡ Bolt: Optimize Date instantiation in Astro content collections

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2024-05-24 - Tag Deduplication Bottleneck
 **Learning:** The Astro static site generation can be slowed down by O(N^2) algorithms in data processing scripts, such as array deduplication using `filter` and `findIndex`, especially when the number of posts grows.
 **Action:** Use a `Map` or `Set` for O(N) deduplication when aggregating large collections of data during the build process to minimize build time.
+
+## 2024-06-13 - Redundant Date Instantiation with Astro Content Collections
+**Learning:** Astro's `z.date()` schema natively parses dates into `Date` objects. Wrapping these fields (like `pubDatetime` or `modDatetime`) in `new Date()` throughout the codebase is redundant and creates unnecessary allocations, which can degrade performance during static site generation and data filtering. Additionally, math operations like `Math.floor(date.getTime() / 1000)` are unnecessary for simple sorting; direct subtraction of milliseconds (`getTime()`) achieves the same result more efficiently.
+**Action:** When working with Astro content collections parsed via `z.date()`, use the date objects directly. Avoid redundant `new Date()` calls and remove unnecessary mathematical operations during sort routines.

--- a/src/pages/archives/index.astro
+++ b/src/pages/archives/index.astro
@@ -62,12 +62,8 @@ const months = [
                     {monthGroup
                       .sort(
                         (a, b) =>
-                          Math.floor(
-                            new Date(b.data.pubDatetime).getTime() / 1000
-                          ) -
-                          Math.floor(
-                            new Date(a.data.pubDatetime).getTime() / 1000
-                          )
+                          b.data.pubDatetime.getTime() -
+                          a.data.pubDatetime.getTime()
                       )
                       .map(data => (
                         <Card {...data} />

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -16,7 +16,7 @@ export async function GET() {
       link: getPath(id, filePath),
       title: data.title,
       description: data.description,
-      pubDate: new Date(data.modDatetime ?? data.pubDatetime),
+      pubDate: data.modDatetime ?? data.pubDatetime,
       customData: [
         `<author>${SITE.author}</author>`,
         ...data.tags.map(tag => `<category>${tag}</category>`),

--- a/src/utils/getSortedPosts.ts
+++ b/src/utils/getSortedPosts.ts
@@ -6,12 +6,8 @@ const getSortedPosts = (posts: CollectionEntry<"blog">[]) => {
     .filter(postFilter)
     .sort(
       (a, b) =>
-        Math.floor(
-          new Date(b.data.modDatetime ?? b.data.pubDatetime).getTime() / 1000
-        ) -
-        Math.floor(
-          new Date(a.data.modDatetime ?? a.data.pubDatetime).getTime() / 1000
-        )
+        (b.data.modDatetime ?? b.data.pubDatetime).getTime() -
+        (a.data.modDatetime ?? a.data.pubDatetime).getTime()
     );
 };
 

--- a/src/utils/postFilter.ts
+++ b/src/utils/postFilter.ts
@@ -3,8 +3,7 @@ import { SITE } from "@/config";
 
 const postFilter = ({ data }: CollectionEntry<"blog">) => {
   const isPublishTimePassed =
-    Date.now() >
-    new Date(data.pubDatetime).getTime() - SITE.scheduledPostMargin;
+    Date.now() > data.pubDatetime.getTime() - SITE.scheduledPostMargin;
   return !data.draft && (import.meta.env.DEV || isPublishTimePassed);
 };
 


### PR DESCRIPTION
💡 **What:** 
Removed redundant `new Date()` wrappers around `pubDatetime` and `modDatetime` variables in `src/utils/getSortedPosts.ts`, `src/utils/postFilter.ts`, `src/pages/rss.xml.ts`, and `src/pages/archives/index.astro`. In Astro content collections, `z.date()` schemas natively output `Date` objects, so these re-wraps were unnecessary. Also simplified the date sorting functions by removing `Math.floor(x.getTime() / 1000)` and performing direct subtraction.

🎯 **Why:** 
Creating new `Date` objects in loops during build-time filtering and generation creates unnecessary garbage collection overhead and compute. Eliminating `Math.floor` also streamlines the comparator sort operations.

📊 **Impact:** 
Small but scalable performance improvement during Astro's static site build process by eliminating unneeded Date object allocation and Math operations.

🔬 **Measurement:** 
Run `pnpm run build` and observe that the build completes successfully and correctly without functional regressions. The build time should be marginally faster.

---
*PR created automatically by Jules for task [14420531622465741136](https://jules.google.com/task/14420531622465741136) started by @PatilShreyas*