### PR TITLE
🎨 Palette: [UX improvement] Discoverable keyboard shortcuts for Lightbox

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,6 @@
 ## 2026-06-09 - Descriptive Action Tooltips on Toggles
 **Learning:** For toggle buttons (like theme switchers), providing an `aria-label` or `title` that purely states the current state (e.g. "dark" or "auto") isn't fully informative to users hovering or using screen readers.
 **Action:** Use action-oriented labels like "Switch to dark theme" so the user knows exactly what will happen when they click it. Keep these attributes dynamic so they always reflect the next intended state.
+## 2025-06-13 - Discoverable Keyboard Shortcuts
+**Learning:** When building complex interactive widgets like lightboxes, keyboard shortcuts are often implemented in JavaScript but remain invisible to users. Screen readers and power users might miss these features.
+**Action:** Always add `aria-keyshortcuts` to buttons with keyboard shortcuts, and append the shortcut hint to the `title` tooltip (e.g., `title="Close (Esc)"`) to bridge the gap and make power-user features discoverable for everyone.

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -27,7 +27,7 @@ const { noMarginTop = false, class: className, ...attrs } = Astro.props;
       class="my-2 flex flex-col items-center text-sm whitespace-nowrap sm:flex-row"
     >
       <span>Copyright &#169; {currentYear}</span>
-      <span class="hidden sm:inline">&nbsp;|&nbsp;</span>
+      <span class="hidden sm:inline" aria-hidden="true">&nbsp;|&nbsp;</span>
       <span>All rights reserved.</span>
     </div>
   </div>

--- a/src/layouts/PostDetails.astro
+++ b/src/layouts/PostDetails.astro
@@ -334,16 +334,16 @@ const nextPost =
       lightbox = document.createElement("div");
       lightbox.id = "lightbox";
       lightbox.innerHTML = `
-        <button class="lightbox-close" aria-label="Close" title="Close">
+        <button class="lightbox-close" aria-label="Close" title="Close (Esc)" aria-keyshortcuts="Escape">
           <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>
         </button>
         <img id="lightbox-img" src="" alt="Full view" />
         <div class="lightbox-controls">
-          <button class="lightbox-btn zoom-out" disabled aria-label="Zoom Out" title="Zoom Out">
+          <button class="lightbox-btn zoom-out" disabled aria-label="Zoom Out" title="Zoom Out (-)" aria-keyshortcuts="-">
             <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="5" y1="12" x2="19" y2="12"></line></svg>
           </button>
           <span class="lightbox-zoom-val">100%</span>
-          <button class="lightbox-btn zoom-in" aria-label="Zoom In" title="Zoom In">
+          <button class="lightbox-btn zoom-in" aria-label="Zoom In" title="Zoom In (+)" aria-keyshortcuts="+">
             <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="5" x2="12" y2="19"></line><line x1="5" y1="12" x2="19" y2="12"></line></svg>
           </button>
         </div>


### PR DESCRIPTION
### 💡 What
- Appended keyboard shortcut hints (like `(Esc)`, `(+)`, `(-)`) to the `title` attributes of the lightbox controls.
- Added `aria-keyshortcuts` attributes to those same buttons.
- Added `aria-hidden="true"` to the decorative vertical bar (`|`) in the footer.
- Logged a learning entry in `.Jules/palette.md` regarding discoverable keyboard shortcuts.

### 🎯 Why
Keyboard shortcuts for the lightbox zoom/close features were implemented in JS, but completely invisible to users unless they stumbled upon them or read the source code. Adding hints to the tooltips bridges this gap. The footer separator fix prevents screen readers from redundantly announcing "vertical bar" when reading copyright text.

### 📸 Before/After
**Before:**
Lightbox Close tooltip: `Close`
Footer text: `Copyright © 2025 | All rights reserved.` (Screen reader reads "vertical line")

**After:**
Lightbox Close tooltip: `Close (Esc)`
Footer text: `Copyright © 2025 All rights reserved.` (Pipe is ignored by screen readers)

### ♿ Accessibility
- `aria-keyshortcuts` provides explicit hints to screen readers about the availability of global keyboard commands for these buttons.
- Hiding decorative text nodes using `aria-hidden="true"` significantly cleans up the semantic output for screen reader navigation.

---
*PR created automatically by Jules for task [7797475264144466906](https://jules.google.com/task/7797475264144466906) started by @PatilShreyas*