### PR TITLE
🎨 Palette: Add aria-current to active navigation links

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2026-06-09 - Descriptive Action Tooltips on Toggles
 **Learning:** For toggle buttons (like theme switchers), providing an `aria-label` or `title` that purely states the current state (e.g. "dark" or "auto") isn't fully informative to users hovering or using screen readers.
 **Action:** Use action-oriented labels like "Switch to dark theme" so the user knows exactly what will happen when they click it. Keep these attributes dynamic so they always reflect the next intended state.
+
+## 2026-06-14 - Active Navigation State Accessibility
+**Learning:** While visual cues like an underline or color change (`active-nav`) indicate the active page, screen reader users rely on the `aria-current="page"` attribute to understand their current location in navigation menus.
+**Action:** Always add `aria-current="page"` dynamically to the active link within a site navigation.

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -70,12 +70,22 @@ const isActive = (path: string) => {
         ]}
       >
         <li class="col-span-2">
-          <a href="/tags" class:list={{ "active-nav": isActive("/tags") }}>
+          <a
+            href="/tags"
+            class:list={{ "active-nav": isActive("/tags") }}
+            aria-current={isActive("/tags") ? "page" : undefined}
+          >
             Tags
           </a>
         </li>
         <li class="col-span-2">
-          <a href="https://shreyaspatil.dev"> About </a>
+          <a
+            href="https://shreyaspatil.dev"
+            class:list={{ "active-nav": isActive("https://shreyaspatil.dev") }}
+            aria-current={isActive("https://shreyaspatil.dev") ? "page" : undefined}
+          >
+            About
+          </a>
         </li>
         {
           SITE.showArchives && (
@@ -90,6 +100,7 @@ const isActive = (path: string) => {
                 ]}
                 title="Archives"
                 aria-label="archives"
+                aria-current={isActive("/archives") ? "page" : undefined}
               >
                 <IconArchive class="hidden sm:inline-block" />
                 <span class="sm:sr-only">Archives</span>
@@ -106,6 +117,7 @@ const isActive = (path: string) => {
             ]}
             title="Search"
             aria-label="search"
+            aria-current={isActive("/search") ? "page" : undefined}
           >
             <IconSearch />
             <span class="sr-only">Search</span>


### PR DESCRIPTION
**What:** Added the `aria-current="page"` attribute dynamically to the header navigation links ("Tags", "About", "Archives", "Search") when they represent the active page.

**Why:** While the active page was visually indicated using the `active-nav` class (which adds a wavy underline), this visual cue is not perceivable by screen readers. Adding `aria-current="page"` semantically communicates the active navigation state to assistive technologies, improving the site's overall accessibility. 

**Before/After:**
- **Before:** Active navigation links were only identifiable visually via CSS styling.
- **After:** Active navigation links now have the standard `aria-current="page"` attribute, making the state machine-readable and accessible to screen readers, while preserving the existing visual styling.

**Accessibility:**
This change specifically targets semantic accessibility by ensuring that active state information is conveyed via ARIA attributes, adhering to standard web accessibility best practices for navigation menus.

---
*PR created automatically by Jules for task [8619207888436503267](https://jules.google.com/task/8619207888436503267) started by @PatilShreyas*