### PR TITLE
🎨 Palette: [UX improvement] Add ARIA label to Back to Top button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2026-06-09 - Descriptive Action Tooltips on Toggles
 **Learning:** For toggle buttons (like theme switchers), providing an `aria-label` or `title` that purely states the current state (e.g. "dark" or "auto") isn't fully informative to users hovering or using screen readers.
 **Action:** Use action-oriented labels like "Switch to dark theme" so the user knows exactly what will happen when they click it. Keep these attributes dynamic so they always reflect the next intended state.
+
+## 2026-06-15 - ARIA Labels for Icon-Only Navigation Controls
+**Learning:** Icon-only navigation controls like the "Back to Top" button often lack accessible names, making them invisible or confusing to screen reader users. The visual context (an upward arrow) is lost without text.
+**Action:** Always ensure that any button or link consisting solely of an icon has a clear, descriptive `aria-label` attribute (e.g., `aria-label="Back to Top"`) to provide parity in experience for assistive technologies.

--- a/src/components/BackToTopButton.astro
+++ b/src/components/BackToTopButton.astro
@@ -12,6 +12,7 @@ import IconArrowNarrowUp from "@/assets/icons/IconArrowNarrowUp.svg";
   ]}
 >
   <button
+    aria-label="Back to Top"
     data-button="back-to-top"
     class:list={[
       "group relative bg-background px-2 py-1",


### PR DESCRIPTION
💡 What: Added an `aria-label="Back to Top"` to the `<button>` element inside `BackToTopButton.astro`.
🎯 Why: The "Back to Top" button only had a visual icon, lacking accessible text for screen reader users, which made the button's purpose unclear or invisible to them.
📸 Before/After: No visual change; strictly a structural accessibility improvement.
♿ Accessibility: Ensures assistive technologies can correctly identify and read the action of returning to the top of the page.

---
*PR created automatically by Jules for task [16920768712959131805](https://jules.google.com/task/16920768712959131805) started by @PatilShreyas*