### PR TITLE
⚡ Bolt: Optimize date processing performance

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2024-05-24 - Tag Deduplication Bottleneck
 **Learning:** The Astro static site generation can be slowed down by O(N^2) algorithms in data processing scripts, such as array deduplication using `filter` and `findIndex`, especially when the number of posts grows.
 **Action:** Use a `Map` or `Set` for O(N) deduplication when aggregating large collections of data during the build process to minimize build time.
+
+## 2025-03-09 - Redundant Date Instantiation in Astro Content Collections
+**Learning:** Astro content collection schema uses `z.date()` which already parses ISO dates into native `Date` objects. Wrapping them in `new Date()` again or using `Math.floor(... / 1000)` for sorting is an unnecessary and redundant CPU cycle operation during builds.
+**Action:** When working with Astro content collections parsed by Zod's `z.date()`, use the native `Date` methods directly (like `.getTime()`) and perform simple subtraction instead of creating new instances or doing extra math when sorting.

--- a/src/pages/archives/index.astro
+++ b/src/pages/archives/index.astro
@@ -62,12 +62,8 @@ const months = [
                     {monthGroup
                       .sort(
                         (a, b) =>
-                          Math.floor(
-                            new Date(b.data.pubDatetime).getTime() / 1000
-                          ) -
-                          Math.floor(
-                            new Date(a.data.pubDatetime).getTime() / 1000
-                          )
+                          b.data.pubDatetime.getTime() -
+                          a.data.pubDatetime.getTime()
                       )
                       .map(data => (
                         <Card {...data} />

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -16,7 +16,7 @@ export async function GET() {
       link: getPath(id, filePath),
       title: data.title,
       description: data.description,
-      pubDate: new Date(data.modDatetime ?? data.pubDatetime),
+      pubDate: data.modDatetime ?? data.pubDatetime,
       customData: [
         `<author>${SITE.author}</author>`,
         ...data.tags.map(tag => `<category>${tag}</category>`),

--- a/src/utils/getSortedPosts.ts
+++ b/src/utils/getSortedPosts.ts
@@ -6,12 +6,8 @@ const getSortedPosts = (posts: CollectionEntry<"blog">[]) => {
     .filter(postFilter)
     .sort(
       (a, b) =>
-        Math.floor(
-          new Date(b.data.modDatetime ?? b.data.pubDatetime).getTime() / 1000
-        ) -
-        Math.floor(
-          new Date(a.data.modDatetime ?? a.data.pubDatetime).getTime() / 1000
-        )
+        (b.data.modDatetime ?? b.data.pubDatetime).getTime() -
+        (a.data.modDatetime ?? a.data.pubDatetime).getTime()
     );
 };
 

--- a/src/utils/postFilter.ts
+++ b/src/utils/postFilter.ts
@@ -4,7 +4,7 @@ import { SITE } from "@/config";
 const postFilter = ({ data }: CollectionEntry<"blog">) => {
   const isPublishTimePassed =
     Date.now() >
-    new Date(data.pubDatetime).getTime() - SITE.scheduledPostMargin;
+    data.pubDatetime.getTime() - SITE.scheduledPostMargin;
   return !data.draft && (import.meta.env.DEV || isPublishTimePassed);
 };
 


### PR DESCRIPTION
💡 **What**: Removed redundant `new Date()` wrappers and `Math.floor(... / 1000)` operations when sorting and filtering dates from Astro's content collections across `src/utils/getSortedPosts.ts`, `src/pages/archives/index.astro`, `src/utils/postFilter.ts`, and `src/pages/rss.xml.ts`.

🎯 **Why**: Astro's Zod schema (`z.date()`) already guarantees that `pubDatetime` and `modDatetime` are native JS `Date` objects. Re-instantiating them and performing floating point math (`Math.floor`) during an `O(N log N)` array sort operation creates unnecessary garbage collection pressure and CPU overhead, especially as the number of blog posts grows.

📊 **Impact**: Reduces CPU overhead and memory churn (GC pauses) during static site generation. The `pnpm run build` command processes collections marginally faster, leading to a cleaner and more efficient build pipeline.

🔬 **Measurement**: Verified by successfully running `pnpm run build` and checking the `dist` directory to confirm static HTML output and PageFind indices are generated cleanly and functionally identical.

---
*PR created automatically by Jules for task [15318830528487882511](https://jules.google.com/task/15318830528487882511) started by @PatilShreyas*