### PR TITLE
🎨 Palette: [Lightbox Accessibility and Tap Feedback Improvements]

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2026-06-09 - Descriptive Action Tooltips on Toggles
 **Learning:** For toggle buttons (like theme switchers), providing an `aria-label` or `title` that purely states the current state (e.g. "dark" or "auto") isn't fully informative to users hovering or using screen readers.
 **Action:** Use action-oriented labels like "Switch to dark theme" so the user knows exactly what will happen when they click it. Keep these attributes dynamic so they always reflect the next intended state.
+
+## 2026-06-16 - Accessible Dynamic Values and Overlays
+**Learning:** JS-generated overlays like Lightbox images often miss screen reader compatibility for dynamic text elements like zoom percentages, and their icon-only buttons can lack clear context or keyboard shortcuts.
+**Action:** When implementing overlays with dynamic state (e.g., zoom values), use `aria-live="polite"` so screen readers announce changes. Additionally, use `title` attributes not just for naming, but also to hint at keyboard shortcuts for better usability.

--- a/src/layouts/PostDetails.astro
+++ b/src/layouts/PostDetails.astro
@@ -334,16 +334,16 @@ const nextPost =
       lightbox = document.createElement("div");
       lightbox.id = "lightbox";
       lightbox.innerHTML = `
-        <button class="lightbox-close" aria-label="Close" title="Close">
+        <button class="lightbox-close" aria-label="Close" title="Close (Esc)">
           <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>
         </button>
         <img id="lightbox-img" src="" alt="Full view" />
         <div class="lightbox-controls">
-          <button class="lightbox-btn zoom-out" disabled aria-label="Zoom Out" title="Zoom Out">
+          <button class="lightbox-btn zoom-out" disabled aria-label="Zoom Out" title="Zoom Out (-)">
             <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="5" y1="12" x2="19" y2="12"></line></svg>
           </button>
-          <span class="lightbox-zoom-val">100%</span>
-          <button class="lightbox-btn zoom-in" aria-label="Zoom In" title="Zoom In">
+          <span class="lightbox-zoom-val" aria-live="polite">100%</span>
+          <button class="lightbox-btn zoom-in" aria-label="Zoom In" title="Zoom In (+)">
             <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="5" x2="12" y2="19"></line><line x1="5" y1="12" x2="19" y2="12"></line></svg>
           </button>
         </div>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -228,7 +228,7 @@ html[data-theme="dark"] mark {
 }
 
 .lightbox-close {
-  @apply absolute top-6 right-6 p-2 text-foreground transition-colors hover:text-accent;
+  @apply absolute top-6 right-6 p-2 text-foreground transition-all hover:text-accent active:scale-95;
 }
 
 .lightbox-controls {
@@ -236,7 +236,7 @@ html[data-theme="dark"] mark {
 }
 
 .lightbox-btn {
-  @apply p-2 text-foreground transition-colors hover:text-accent disabled:pointer-events-none disabled:opacity-30;
+  @apply p-2 text-foreground transition-all hover:text-accent active:scale-95 disabled:pointer-events-none disabled:opacity-30;
 }
 
 .lightbox-zoom-val {


### PR DESCRIPTION
💡 **What**: 
- Added `aria-live="polite"` to the Lightbox zoom level `.lightbox-zoom-val` to make dynamic zoom text accessible to screen readers.
- Added keyboard shortcuts to Lightbox button `title` attributes (e.g., `Close (Esc)`, `Zoom Out (-)`, `Zoom In (+)`).
- Applied `active:scale-95` to `.lightbox-btn` and `.lightbox-close` for interactive physical tap feedback.
- Documented these accessible dynamic overlay learnings in `.Jules/palette.md`.

🎯 **Why**: 
Screen readers often miss text updates in JS-generated overlays without `aria-live`. Keyboard shortcuts hidden in documentation are difficult to discover; adding them directly to the tooltip helps users learn them. Finally, adding physical-feeling tap feedback (scaling down) to elements provides satisfying and immediate confirmation of interactions.

📸 **Before/After**: 
- Visual changes are subtle (tap scaling down by 5% when clicked).
- Hovering over buttons now reveals tooltips such as "Close (Esc)" instead of just "Close".

♿ **Accessibility**: 
- Added `aria-live="polite"` so screen readers actively announce when the user zooms in or out on a Lightbox image.
- Improved discoverability of keyboard interaction through descriptive tooltip titles.

---
*PR created automatically by Jules for task [4774782837055664850](https://jules.google.com/task/4774782837055664850) started by @PatilShreyas*