### PR TITLE
⚡ Bolt: [performance improvement] Remove redundant Date instantiations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2024-05-24 - Tag Deduplication Bottleneck
 **Learning:** The Astro static site generation can be slowed down by O(N^2) algorithms in data processing scripts, such as array deduplication using `filter` and `findIndex`, especially when the number of posts grows.
 **Action:** Use a `Map` or `Set` for O(N) deduplication when aggregating large collections of data during the build process to minimize build time.
+## 2025-02-12 - Redundant Date Instantiation Bottleneck
+**Learning:** Astro's content collection schema (defined in `src/content.config.ts` via Zod) parses `pubDatetime` and `modDatetime` as native `Date` objects. Wrapping them in `new Date()` and performing math operations like `Math.floor(... / 1000)` inside sorting and filtering loops is unnecessary and slows down the build process.
+**Action:** Avoid redundant `new Date()` wrappers for pre-parsed date fields and use direct millisecond subtraction (`.getTime()`) for optimal performance when sorting and filtering content collections.

--- a/src/pages/archives/index.astro
+++ b/src/pages/archives/index.astro
@@ -62,12 +62,8 @@ const months = [
                     {monthGroup
                       .sort(
                         (a, b) =>
-                          Math.floor(
-                            new Date(b.data.pubDatetime).getTime() / 1000
-                          ) -
-                          Math.floor(
-                            new Date(a.data.pubDatetime).getTime() / 1000
-                          )
+                          b.data.pubDatetime.getTime() -
+                          a.data.pubDatetime.getTime()
                       )
                       .map(data => (
                         <Card {...data} />

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -16,7 +16,7 @@ export async function GET() {
       link: getPath(id, filePath),
       title: data.title,
       description: data.description,
-      pubDate: new Date(data.modDatetime ?? data.pubDatetime),
+      pubDate: data.modDatetime ?? data.pubDatetime,
       customData: [
         `<author>${SITE.author}</author>`,
         ...data.tags.map(tag => `<category>${tag}</category>`),

--- a/src/utils/getSortedPosts.ts
+++ b/src/utils/getSortedPosts.ts
@@ -6,12 +6,8 @@ const getSortedPosts = (posts: CollectionEntry<"blog">[]) => {
     .filter(postFilter)
     .sort(
       (a, b) =>
-        Math.floor(
-          new Date(b.data.modDatetime ?? b.data.pubDatetime).getTime() / 1000
-        ) -
-        Math.floor(
-          new Date(a.data.modDatetime ?? a.data.pubDatetime).getTime() / 1000
-        )
+        (b.data.modDatetime ?? b.data.pubDatetime).getTime() -
+        (a.data.modDatetime ?? a.data.pubDatetime).getTime()
     );
 };
 

--- a/src/utils/postFilter.ts
+++ b/src/utils/postFilter.ts
@@ -4,7 +4,7 @@ import { SITE } from "@/config";
 const postFilter = ({ data }: CollectionEntry<"blog">) => {
   const isPublishTimePassed =
     Date.now() >
-    new Date(data.pubDatetime).getTime() - SITE.scheduledPostMargin;
+    data.pubDatetime.getTime() - SITE.scheduledPostMargin;
   return !data.draft && (import.meta.env.DEV || isPublishTimePassed);
 };
 


### PR DESCRIPTION
💡 **What:** Removed redundant `new Date()` instantiations and unnecessary `Math.floor(... / 1000)` wrappers around fields like `pubDatetime` and `modDatetime` when sorting or filtering posts. Used direct `.getTime()` subtraction for cleaner, more efficient sorting.

🎯 **Why:** Astro's Zod schema natively parses these date fields as JS `Date` objects. Wrapping them again in `new Date()` creates unnecessary object allocations, and doing extra mathematical operations slows down O(N log N) sorting logic during site build.

📊 **Impact:** Reduces object instantiations and mathematical overhead in loops handling large collections of posts, speeding up the overall SSG build process. 

🔬 **Measurement:** Verify by running `pnpm run build` and checking the build times against a large content directory, ensuring successful generation without loss of sorting precision.

---
*PR created automatically by Jules for task [9174471757040770894](https://jules.google.com/task/9174471757040770894) started by @PatilShreyas*