### PR TITLE
🎨 Palette: [Accessibility] Improve pagination screen reader context

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,6 @@
 ## 2026-06-09 - Descriptive Action Tooltips on Toggles
 **Learning:** For toggle buttons (like theme switchers), providing an `aria-label` or `title` that purely states the current state (e.g. "dark" or "auto") isn't fully informative to users hovering or using screen readers.
 **Action:** Use action-oriented labels like "Switch to dark theme" so the user knows exactly what will happen when they click it. Keep these attributes dynamic so they always reflect the next intended state.
+## 2026-06-17 - [Improve pagination screen reader context]
+**Learning:** Raw text like 'X / Y' in pagination components can confuse screen readers (often read as 'one slash five'). Hiding the raw text with `aria-hidden="true"` and adding a visually hidden element with the `sr-only` class and descriptive text (e.g., 'Page X of Y') drastically improves screen reader experience.
+**Action:** Always wrap pagination page counts with an `aria-hidden` span and include a screen-reader-only alternative using `sr-only` classes to explicitly convey current position and total pages.

--- a/src/components/Pagination.astro
+++ b/src/components/Pagination.astro
@@ -31,7 +31,12 @@ const prevUrl = page.url.prev === "/posts/1" ? "/" : page.url.prev;
         <IconArrowLeft class="inline-block rtl:rotate-180" />
         Prev
       </LinkButton>
-      {page.currentPage} / {page.lastPage}
+      <span aria-hidden="true">
+        {page.currentPage} / {page.lastPage}
+      </span>
+      <span class="sr-only">
+        Page {page.currentPage} of {page.lastPage}
+      </span>
       <LinkButton
         disabled={!page.url.next}
         href={page.url.next as string}


### PR DESCRIPTION
💡 **What:** Replaced the raw text `X / Y` in the pagination component with an `aria-hidden` span and a visually hidden `sr-only` span containing "Page X of Y".

🎯 **Why:** To drastically improve the experience for users who rely on screen readers.

📸 **Before/After:** Visually identical.

♿ **Accessibility:** Screen readers will no longer read raw text such as "one slash five" but will explicitly convey "Page 1 of 5".

---
*PR created automatically by Jules for task [12692385385276926100](https://jules.google.com/task/12692385385276926100) started by @PatilShreyas*