### PR TITLE
⚡ Bolt: [performance improvement] Remove redundant Date instantiation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2024-05-24 - Tag Deduplication Bottleneck
 **Learning:** The Astro static site generation can be slowed down by O(N^2) algorithms in data processing scripts, such as array deduplication using `filter` and `findIndex`, especially when the number of posts grows.
 **Action:** Use a `Map` or `Set` for O(N) deduplication when aggregating large collections of data during the build process to minimize build time.
+## 2024-11-20 - Redundant Date Instantiation in Astro
+
+**Learning:** Astro's Content Collection schemas (via Zod) parse dates like `pubDatetime` and `modDatetime` into native JavaScript `Date` objects. Re-wrapping these in `new Date()` is unnecessary and can add minor performance overhead (allocations, object creation). Similarly, using `Math.floor(date.getTime() / 1000)` during sorting is an unnecessary step; direct subtraction of `.getTime()` values works perfectly and is more efficient.
+**Action:** When working with Astro content collections, directly use the Date object properties methods (e.g. `.getTime()`) and avoid re-wrapping them in `new Date()`. Additionally, avoid unnecessary math operations during simple comparison sorting.

--- a/src/pages/archives/index.astro
+++ b/src/pages/archives/index.astro
@@ -62,12 +62,8 @@ const months = [
                     {monthGroup
                       .sort(
                         (a, b) =>
-                          Math.floor(
-                            new Date(b.data.pubDatetime).getTime() / 1000
-                          ) -
-                          Math.floor(
-                            new Date(a.data.pubDatetime).getTime() / 1000
-                          )
+                          b.data.pubDatetime.getTime() -
+                          a.data.pubDatetime.getTime()
                       )
                       .map(data => (
                         <Card {...data} />

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -16,7 +16,7 @@ export async function GET() {
       link: getPath(id, filePath),
       title: data.title,
       description: data.description,
-      pubDate: new Date(data.modDatetime ?? data.pubDatetime),
+      pubDate: data.modDatetime ?? data.pubDatetime,
       customData: [
         `<author>${SITE.author}</author>`,
         ...data.tags.map(tag => `<category>${tag}</category>`),

--- a/src/utils/getSortedPosts.ts
+++ b/src/utils/getSortedPosts.ts
@@ -6,12 +6,8 @@ const getSortedPosts = (posts: CollectionEntry<"blog">[]) => {
     .filter(postFilter)
     .sort(
       (a, b) =>
-        Math.floor(
-          new Date(b.data.modDatetime ?? b.data.pubDatetime).getTime() / 1000
-        ) -
-        Math.floor(
-          new Date(a.data.modDatetime ?? a.data.pubDatetime).getTime() / 1000
-        )
+        (b.data.modDatetime ?? b.data.pubDatetime).getTime() -
+        (a.data.modDatetime ?? a.data.pubDatetime).getTime()
     );
 };
 

--- a/src/utils/postFilter.ts
+++ b/src/utils/postFilter.ts
@@ -4,7 +4,7 @@ import { SITE } from "@/config";
 const postFilter = ({ data }: CollectionEntry<"blog">) => {
   const isPublishTimePassed =
     Date.now() >
-    new Date(data.pubDatetime).getTime() - SITE.scheduledPostMargin;
+    data.pubDatetime.getTime() - SITE.scheduledPostMargin;
   return !data.draft && (import.meta.env.DEV || isPublishTimePassed);
 };
 


### PR DESCRIPTION
💡 What: Removed unnecessary `new Date()` wrapping around `pubDatetime` and `modDatetime` objects since they are already parsed as native `Date` objects by Astro's content collections. Also simplified the date sorting logic by replacing `Math.floor(date.getTime() / 1000)` with direct subtraction of milliseconds.
🎯 Why: Instantiating new Date objects unnecessarily creates memory allocation overhead. Also using `Math.floor(date.getTime() / 1000)` during sorting is an unnecessary extra step when sorting by raw milliseconds is computationally cheaper and achieves the same result (with slightly better precision).
📊 Impact: Very slightly faster build times and page generation times, reducing the garbage collection overhead by eliminating unnecessary object allocations during mapping and sorting of blog posts.
🔬 Measurement: Run `pnpm run build` before and after to verify that the build succeeds and functions correctly.

---
*PR created automatically by Jules for task [4879829678126143822](https://jules.google.com/task/4879829678126143822) started by @PatilShreyas*