### PR TITLE
🎨 Palette: [UX improvement] Add aria-label to heading links

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2026-06-09 - Descriptive Action Tooltips on Toggles
 **Learning:** For toggle buttons (like theme switchers), providing an `aria-label` or `title` that purely states the current state (e.g. "dark" or "auto") isn't fully informative to users hovering or using screen readers.
 **Action:** Use action-oriented labels like "Switch to dark theme" so the user knows exactly what will happen when they click it. Keep these attributes dynamic so they always reflect the next intended state.
+
+## 2026-06-18 - Accessible Icon-Only Anchor Links
+**Learning:** Icon-only anchor links generated dynamically via JavaScript (such as heading anchor links) often lack accessible names because they typically contain just a symbol (like "#") hidden with `aria-hidden="true"`, causing screen readers to skip them or read out confusing contexts.
+**Action:** Always assign meaningful `aria-label` and `title` attributes to generated icon-only links based on the context they link to (e.g. use the text content of the heading to provide "Link to section: [Heading]").

--- a/src/layouts/PostDetails.astro
+++ b/src/layouts/PostDetails.astro
@@ -253,6 +253,10 @@ const nextPost =
         "heading-link ms-2 no-underline opacity-75 md:opacity-0 md:group-hover:opacity-100 md:focus:opacity-100";
       link.href = "#" + heading.id;
 
+      const headingText = heading.textContent || "";
+      link.setAttribute("aria-label", `Link to section: ${headingText}`);
+      link.setAttribute("title", `Link to section: ${headingText}`);
+
       const span = document.createElement("span");
       span.ariaHidden = "true";
       span.innerText = "#";


### PR DESCRIPTION
💡 **What:** Added dynamic `aria-label` and `title` attributes to the auto-generated heading anchor links (the "#" icons next to h2, h3, etc.).
🎯 **Why:** Previously, these links only contained a "#" span hidden via `aria-hidden="true"`. Screen readers couldn't announce the link destination properly, and sighted users lacked a descriptive tooltip when hovering.
📸 **Before/After:** Before, the `a` tag had no accessible label. After, it reads "Link to section: [Heading Text]". Sighted users will see this tooltip on hover.
♿ **Accessibility:** This gives an accessible name to interactive, icon-only link elements, improving navigation for assistive technology users.

---
*PR created automatically by Jules for task [13244643822193654444](https://jules.google.com/task/13244643822193654444) started by @PatilShreyas*