### PR TITLE
🎨 Palette: Add `aria-current="page"` to active navigation links

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,6 @@
 ## 2026-06-09 - Descriptive Action Tooltips on Toggles
 **Learning:** For toggle buttons (like theme switchers), providing an `aria-label` or `title` that purely states the current state (e.g. "dark" or "auto") isn't fully informative to users hovering or using screen readers.
 **Action:** Use action-oriented labels like "Switch to dark theme" so the user knows exactly what will happen when they click it. Keep these attributes dynamic so they always reflect the next intended state.
+## 2025-06-19 - Active Navigation Links Missing Spatial Context
+**Learning:** Adding a visual active state (like an underline or color change) to a navigation link is insufficient for screen reader users. They need a semantic indicator to understand which page is currently active.
+**Action:** Always add `aria-current="page"` dynamically to the active item in navigation lists to ensure proper spatial orientation for screen reader users.

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -42,7 +42,10 @@ const isActive = (path: string) => {
   >
     <a
       href="/"
-      class="absolute py-1 text-xl leading-8 font-semibold whitespace-nowrap sm:static sm:my-auto sm:text-2xl sm:leading-none"
+      class:list={[
+        "absolute py-1 text-xl leading-8 font-semibold whitespace-nowrap sm:static sm:my-auto sm:text-2xl sm:leading-none",
+      ]}
+      aria-current={currentPath === "/" ? "page" : undefined}
     >
       {SITE.title}
     </a>
@@ -70,7 +73,11 @@ const isActive = (path: string) => {
         ]}
       >
         <li class="col-span-2">
-          <a href="/tags" class:list={{ "active-nav": isActive("/tags") }}>
+          <a
+            href="/tags"
+            class:list={{ "active-nav": isActive("/tags") }}
+            aria-current={isActive("/tags") ? "page" : undefined}
+          >
             Tags
           </a>
         </li>
@@ -90,6 +97,7 @@ const isActive = (path: string) => {
                 ]}
                 title="Archives"
                 aria-label="archives"
+                aria-current={isActive("/archives") ? "page" : undefined}
               >
                 <IconArchive class="hidden sm:inline-block" />
                 <span class="sm:sr-only">Archives</span>
@@ -106,6 +114,7 @@ const isActive = (path: string) => {
             ]}
             title="Search"
             aria-label="search"
+            aria-current={isActive("/search") ? "page" : undefined}
           >
             <IconSearch />
             <span class="sr-only">Search</span>


### PR DESCRIPTION
**What:** 
Added `aria-current="page"` dynamically to active navigation links in `src/components/Header.astro`. The attribute is rendered only when the link corresponds to the currently active page/path. Also added a journal entry to `.Jules/palette.md` for this accessibility finding.

**Why:**
While the interface previously provided a visual indicator for the active navigation link (`.active-nav`), screen readers lacked semantic context to announce which page was currently active. Adding `aria-current="page"` resolves this, allowing non-visual users to orient themselves successfully within the main navigation menu.

**Before/After:**
- **Before:** Active navigation link visually highlighted, but the HTML was simply `<a href="/tags" class="active-nav">Tags</a>`
- **After:** Active navigation link provides semantic context to screen readers: `<a href="/tags" class="active-nav" aria-current="page">Tags</a>`

**Accessibility:**
This fix directly improves screen reader accessibility and navigation clarity by ensuring proper spatial context according to standard ARIA guidelines.

---
*PR created automatically by Jules for task [2279112017201564352](https://jules.google.com/task/2279112017201564352) started by @PatilShreyas*