### PR TITLE
⚡ Bolt: Remove redundant Date parsing and math operations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2024-05-24 - Tag Deduplication Bottleneck
 **Learning:** The Astro static site generation can be slowed down by O(N^2) algorithms in data processing scripts, such as array deduplication using `filter` and `findIndex`, especially when the number of posts grows.
 **Action:** Use a `Map` or `Set` for O(N) deduplication when aggregating large collections of data during the build process to minimize build time.
+## 2024-06-19 - Avoid redundant Date parsing in Astro content collections
+**Learning:** Astro content collection schema (defined in `src/content.config.ts` via Zod) parses `pubDatetime` and `modDatetime` as native `Date` objects. Wrapping them in `new Date()` calls or using `Math.floor(date.getTime() / 1000)` when sorting is redundant and adds unnecessary CPU overhead for every item.
+**Action:** Avoid redundant `new Date()` parsing for Astro collection properties that are already `Date` objects, and sort directly by comparing millisecond timestamps (e.g. `b.getTime() - a.getTime()`) rather than converting to seconds via `Math.floor`.

--- a/src/pages/archives/index.astro
+++ b/src/pages/archives/index.astro
@@ -62,12 +62,8 @@ const months = [
                     {monthGroup
                       .sort(
                         (a, b) =>
-                          Math.floor(
-                            new Date(b.data.pubDatetime).getTime() / 1000
-                          ) -
-                          Math.floor(
-                            new Date(a.data.pubDatetime).getTime() / 1000
-                          )
+                          b.data.pubDatetime.getTime() -
+                          a.data.pubDatetime.getTime()
                       )
                       .map(data => (
                         <Card {...data} />

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -16,7 +16,7 @@ export async function GET() {
       link: getPath(id, filePath),
       title: data.title,
       description: data.description,
-      pubDate: new Date(data.modDatetime ?? data.pubDatetime),
+      pubDate: data.modDatetime ?? data.pubDatetime,
       customData: [
         `<author>${SITE.author}</author>`,
         ...data.tags.map(tag => `<category>${tag}</category>`),

--- a/src/utils/getSortedPosts.ts
+++ b/src/utils/getSortedPosts.ts
@@ -6,12 +6,8 @@ const getSortedPosts = (posts: CollectionEntry<"blog">[]) => {
     .filter(postFilter)
     .sort(
       (a, b) =>
-        Math.floor(
-          new Date(b.data.modDatetime ?? b.data.pubDatetime).getTime() / 1000
-        ) -
-        Math.floor(
-          new Date(a.data.modDatetime ?? a.data.pubDatetime).getTime() / 1000
-        )
+        (b.data.modDatetime ?? b.data.pubDatetime).getTime() -
+        (a.data.modDatetime ?? a.data.pubDatetime).getTime()
     );
 };
 

--- a/src/utils/postFilter.ts
+++ b/src/utils/postFilter.ts
@@ -4,7 +4,7 @@ import { SITE } from "@/config";
 const postFilter = ({ data }: CollectionEntry<"blog">) => {
   const isPublishTimePassed =
     Date.now() >
-    new Date(data.pubDatetime).getTime() - SITE.scheduledPostMargin;
+    data.pubDatetime.getTime() - SITE.scheduledPostMargin;
   return !data.draft && (import.meta.env.DEV || isPublishTimePassed);
 };
 


### PR DESCRIPTION
💡 What: Removed redundant `new Date()` wrappers around Astro content collection `pubDatetime` and `modDatetime` fields, which are already native `Date` objects. Replaced `Math.floor(date.getTime() / 1000)` with direct millisecond subtractions when sorting.
🎯 Why: Astro's Zod schema natively parses these frontmatter properties as `Date` objects. Re-parsing them and dividing to seconds just for sorting adds unnecessary CPU overhead for each iteration during static site builds.
📊 Impact: Decreases loop processing time and memory allocations during AST build functions (filtering, mapping, sorting pages).
🔬 Measurement: Run `pnpm run build` and ensure builds complete slightly faster without issues, validating date values continue sorting as expected.

---
*PR created automatically by Jules for task [15249420890818014125](https://jules.google.com/task/15249420890818014125) started by @PatilShreyas*