### PR TITLE
🎨 Palette: [UX improvement] Add aria-current to active header navigation links

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,6 @@
 ## 2026-06-09 - Descriptive Action Tooltips on Toggles
 **Learning:** For toggle buttons (like theme switchers), providing an `aria-label` or `title` that purely states the current state (e.g. "dark" or "auto") isn't fully informative to users hovering or using screen readers.
 **Action:** Use action-oriented labels like "Switch to dark theme" so the user knows exactly what will happen when they click it. Keep these attributes dynamic so they always reflect the next intended state.
+## 2026-06-20 - Conditional Attributes in Astro
+**Learning:** In Astro components, you can conditionally add an attribute by setting its value to undefined when it should be omitted, e.g. `aria-current={isActive("/tags") ? "page" : undefined}`.
+**Action:** Use this pattern to clean up conditionally applied ARIA and other attributes in Astro files without needing to wrap elements in complex conditional logic.

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -70,7 +70,11 @@ const isActive = (path: string) => {
         ]}
       >
         <li class="col-span-2">
-          <a href="/tags" class:list={{ "active-nav": isActive("/tags") }}>
+          <a
+            href="/tags"
+            class:list={{ "active-nav": isActive("/tags") }}
+            aria-current={isActive("/tags") ? "page" : undefined}
+          >
             Tags
           </a>
         </li>
@@ -90,6 +94,7 @@ const isActive = (path: string) => {
                 ]}
                 title="Archives"
                 aria-label="archives"
+                aria-current={isActive("/archives") ? "page" : undefined}
               >
                 <IconArchive class="hidden sm:inline-block" />
                 <span class="sm:sr-only">Archives</span>
@@ -106,6 +111,7 @@ const isActive = (path: string) => {
             ]}
             title="Search"
             aria-label="search"
+            aria-current={isActive("/search") ? "page" : undefined}
           >
             <IconSearch />
             <span class="sr-only">Search</span>


### PR DESCRIPTION
💡 What: Added `aria-current="page"` to Header navigation links when they are active.
🎯 Why: To provide correct spatial context to screen reader users, indicating which navigation item represents the current page.
📸 Before/After: Visuals remain unchanged. The HTML now includes `aria-current="page"` on active navigation items instead of just an `active-nav` class.
♿ Accessibility: Improves navigation accessibility for users relying on screen readers by explicitly announcing the active state.

---
*PR created automatically by Jules for task [16923292333291427131](https://jules.google.com/task/16923292333291427131) started by @PatilShreyas*