### PR TITLE
⚡ Bolt: Remove redundant Date instantiation and math in sorting

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2024-05-24 - Tag Deduplication Bottleneck
 **Learning:** The Astro static site generation can be slowed down by O(N^2) algorithms in data processing scripts, such as array deduplication using `filter` and `findIndex`, especially when the number of posts grows.
 **Action:** Use a `Map` or `Set` for O(N) deduplication when aggregating large collections of data during the build process to minimize build time.
+
+## 2026-06-20 - Date Initialization Redundancy
+**Learning:** Instantiating new `Date()` objects inside sort functions for `pubDatetime` and `modDatetime` when they are already defined as `Date` objects in the Zod schema (`src/content.config.ts`) adds unnecessary overhead to array sorting.
+**Action:** Use `.getTime()` directly on the schema-parsed Date objects during sorting to prevent redundant initialization and avoid integer math operations like `Math.floor` when direct millisecond subtraction suffices.

--- a/src/pages/archives/index.astro
+++ b/src/pages/archives/index.astro
@@ -62,12 +62,8 @@ const months = [
                     {monthGroup
                       .sort(
                         (a, b) =>
-                          Math.floor(
-                            new Date(b.data.pubDatetime).getTime() / 1000
-                          ) -
-                          Math.floor(
-                            new Date(a.data.pubDatetime).getTime() / 1000
-                          )
+                          b.data.pubDatetime.getTime() -
+                          a.data.pubDatetime.getTime()
                       )
                       .map(data => (
                         <Card {...data} />

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -16,7 +16,7 @@ export async function GET() {
       link: getPath(id, filePath),
       title: data.title,
       description: data.description,
-      pubDate: new Date(data.modDatetime ?? data.pubDatetime),
+      pubDate: data.modDatetime ?? data.pubDatetime,
       customData: [
         `<author>${SITE.author}</author>`,
         ...data.tags.map(tag => `<category>${tag}</category>`),

--- a/src/utils/getSortedPosts.ts
+++ b/src/utils/getSortedPosts.ts
@@ -6,12 +6,8 @@ const getSortedPosts = (posts: CollectionEntry<"blog">[]) => {
     .filter(postFilter)
     .sort(
       (a, b) =>
-        Math.floor(
-          new Date(b.data.modDatetime ?? b.data.pubDatetime).getTime() / 1000
-        ) -
-        Math.floor(
-          new Date(a.data.modDatetime ?? a.data.pubDatetime).getTime() / 1000
-        )
+        (b.data.modDatetime ?? b.data.pubDatetime).getTime() -
+        (a.data.modDatetime ?? a.data.pubDatetime).getTime()
     );
 };
 

--- a/src/utils/postFilter.ts
+++ b/src/utils/postFilter.ts
@@ -4,7 +4,7 @@ import { SITE } from "@/config";
 const postFilter = ({ data }: CollectionEntry<"blog">) => {
   const isPublishTimePassed =
     Date.now() >
-    new Date(data.pubDatetime).getTime() - SITE.scheduledPostMargin;
+    data.pubDatetime.getTime() - SITE.scheduledPostMargin;
   return !data.draft && (import.meta.env.DEV || isPublishTimePassed);
 };
 


### PR DESCRIPTION
💡 What: Removed redundant `new Date()` wrappers around schema-parsed `Date` objects and replaced integer division math (`Math.floor(x / 1000)`) with direct `.getTime()` subtraction in post sorting utilities.
🎯 Why: Astro’s content collections automatically parse `pubDatetime` and `modDatetime` into native `Date` objects via the Zod schema. Wrapping them in new `Date()` objects during repetitive sorting operations is an unnecessary object allocation overhead.
📊 Impact: Minor improvement in build times by eliminating O(N*logN) redundant date instantiations and math operations during array sorting.
🔬 Measurement: Verified by running `pnpm run build` which shows the build remains successful and preserves correct sorting without regression.

---
*PR created automatically by Jules for task [5406508227929019700](https://jules.google.com/task/5406508227929019700) started by @PatilShreyas*