### PR TITLE
🎨 Palette: Add `aria-current` to active navigation links

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2026-06-09 - Descriptive Action Tooltips on Toggles
 **Learning:** For toggle buttons (like theme switchers), providing an `aria-label` or `title` that purely states the current state (e.g. "dark" or "auto") isn't fully informative to users hovering or using screen readers.
 **Action:** Use action-oriented labels like "Switch to dark theme" so the user knows exactly what will happen when they click it. Keep these attributes dynamic so they always reflect the next intended state.
+
+## 2026-06-10 - Accessible Active Navigation States
+**Learning:** For accessible navigation, always pair visual active states (e.g., active navigation link styling like `.active-nav`) with `aria-current="page"` to provide correct spatial context to screen reader users. Simply styling a link differently doesn't communicate its state as the "current page" to assistive technologies.
+**Action:** When creating or modifying navigation menus, ensure that the active link has `aria-current="page"` dynamically applied alongside its active visual CSS classes. In Astro components, conditional HTML attributes should be set to `undefined` (e.g., `aria-current={isActive ? 'page' : undefined}`) to cleanly omit the attribute from the rendered HTML when the condition is false.

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -70,7 +70,11 @@ const isActive = (path: string) => {
         ]}
       >
         <li class="col-span-2">
-          <a href="/tags" class:list={{ "active-nav": isActive("/tags") }}>
+          <a
+            href="/tags"
+            class:list={{ "active-nav": isActive("/tags") }}
+            aria-current={isActive("/tags") ? "page" : undefined}
+          >
             Tags
           </a>
         </li>
@@ -90,6 +94,7 @@ const isActive = (path: string) => {
                 ]}
                 title="Archives"
                 aria-label="archives"
+                aria-current={isActive("/archives") ? "page" : undefined}
               >
                 <IconArchive class="hidden sm:inline-block" />
                 <span class="sm:sr-only">Archives</span>
@@ -106,6 +111,7 @@ const isActive = (path: string) => {
             ]}
             title="Search"
             aria-label="search"
+            aria-current={isActive("/search") ? "page" : undefined}
           >
             <IconSearch />
             <span class="sr-only">Search</span>


### PR DESCRIPTION
💡 What: Added `aria-current="page"` dynamically to the active navigation menu links (Tags, Archives, Search).
🎯 Why: When navigating through the site, screen readers weren't told which page was the current one, since the active state was purely visual CSS.
📸 Before/After: No visual changes; purely an accessibility enhancement behind the scenes.
♿ Accessibility: Provides critical spatial context to assistive technologies so users know their current location within the navigation menu. Added a journal entry to `.Jules/palette.md` to establish this as a standard pattern.

---
*PR created automatically by Jules for task [13891742958085622929](https://jules.google.com/task/13891742958085622929) started by @PatilShreyas*