### PR TITLE
🎨 Palette: Add aria-current to active navigation links

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2026-06-09 - Descriptive Action Tooltips on Toggles
 **Learning:** For toggle buttons (like theme switchers), providing an `aria-label` or `title` that purely states the current state (e.g. "dark" or "auto") isn't fully informative to users hovering or using screen readers.
 **Action:** Use action-oriented labels like "Switch to dark theme" so the user knows exactly what will happen when they click it. Keep these attributes dynamic so they always reflect the next intended state.
+
+## 2026-06-10 - Active State Accessibility in Astro
+**Learning:** For accessible navigation, providing visual active states (e.g., active navigation link styling) is not enough. Screen readers need `aria-current="page"` to understand the spatial context. In Astro, setting an attribute to `undefined` completely removes it from the rendered HTML, making it a perfect pattern for conditional attributes.
+**Action:** Always pair visual active states with `aria-current={isActive ? 'page' : undefined}` in navigation menus to provide correct context to screen reader users.

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -70,7 +70,11 @@ const isActive = (path: string) => {
         ]}
       >
         <li class="col-span-2">
-          <a href="/tags" class:list={{ "active-nav": isActive("/tags") }}>
+          <a
+            href="/tags"
+            class:list={{ "active-nav": isActive("/tags") }}
+            aria-current={isActive("/tags") ? "page" : undefined}
+          >
             Tags
           </a>
         </li>
@@ -90,6 +94,7 @@ const isActive = (path: string) => {
                 ]}
                 title="Archives"
                 aria-label="archives"
+                aria-current={isActive("/archives") ? "page" : undefined}
               >
                 <IconArchive class="hidden sm:inline-block" />
                 <span class="sm:sr-only">Archives</span>
@@ -106,6 +111,7 @@ const isActive = (path: string) => {
             ]}
             title="Search"
             aria-label="search"
+            aria-current={isActive("/search") ? "page" : undefined}
           >
             <IconSearch />
             <span class="sr-only">Search</span>


### PR DESCRIPTION
*   💡 What: Added `aria-current="page"` dynamically to active navigation links.
*   🎯 Why: To improve accessibility for screen reader users by providing the correct spatial context that was previously only conveyed visually.
*   📸 Before/After: Visuals remain unchanged, but assistive technologies now properly announce the current active page.
*   ♿ Accessibility: Significant improvement for users relying on screen readers to navigate the application menu.

---
*PR created automatically by Jules for task [6215200747256439805](https://jules.google.com/task/6215200747256439805) started by @PatilShreyas*