### PR TITLE
⚡ Bolt: [performance improvement] Optimize Date Sorting and Date Object Parsing during build

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2024-05-24 - Tag Deduplication Bottleneck
 **Learning:** The Astro static site generation can be slowed down by O(N^2) algorithms in data processing scripts, such as array deduplication using `filter` and `findIndex`, especially when the number of posts grows.
 **Action:** Use a `Map` or `Set` for O(N) deduplication when aggregating large collections of data during the build process to minimize build time.
+
+## 2024-06-23 - Astro Zod Date Optimization
+**Learning:** Astro content collections parsed with Zod `z.date()` provide native `Date` objects.
+**Action:** Avoid wrapping them in `new Date()` and avoid redundant math operations in tight loops (like sorting) to improve static generation performance.

--- a/src/pages/archives/index.astro
+++ b/src/pages/archives/index.astro
@@ -62,12 +62,8 @@ const months = [
                     {monthGroup
                       .sort(
                         (a, b) =>
-                          Math.floor(
-                            new Date(b.data.pubDatetime).getTime() / 1000
-                          ) -
-                          Math.floor(
-                            new Date(a.data.pubDatetime).getTime() / 1000
-                          )
+                          b.data.pubDatetime.getTime() -
+                          a.data.pubDatetime.getTime()
                       )
                       .map(data => (
                         <Card {...data} />

--- a/src/utils/getSortedPosts.ts
+++ b/src/utils/getSortedPosts.ts
@@ -6,12 +6,8 @@ const getSortedPosts = (posts: CollectionEntry<"blog">[]) => {
     .filter(postFilter)
     .sort(
       (a, b) =>
-        Math.floor(
-          new Date(b.data.modDatetime ?? b.data.pubDatetime).getTime() / 1000
-        ) -
-        Math.floor(
-          new Date(a.data.modDatetime ?? a.data.pubDatetime).getTime() / 1000
-        )
+        (b.data.modDatetime ?? b.data.pubDatetime).getTime() -
+        (a.data.modDatetime ?? a.data.pubDatetime).getTime()
     );
 };
 

--- a/src/utils/postFilter.ts
+++ b/src/utils/postFilter.ts
@@ -4,7 +4,7 @@ import { SITE } from "@/config";
 const postFilter = ({ data }: CollectionEntry<"blog">) => {
   const isPublishTimePassed =
     Date.now() >
-    new Date(data.pubDatetime).getTime() - SITE.scheduledPostMargin;
+    data.pubDatetime.getTime() - SITE.scheduledPostMargin;
   return !data.draft && (import.meta.env.DEV || isPublishTimePassed);
 };
 


### PR DESCRIPTION
💡 **What**: Avoided redundant `new Date()` instantiation and `Math.floor` divisions when sorting `pubDatetime` and `modDatetime` strings. Since Astro Content Collections already parse these into native `Date` objects with Zod schemas, they can simply be queried via `.getTime()`.

🎯 **Why**: Using `new Date(nativeDate)` or doing `Math.floor(x/1000)` on every comparison iteration slows down Astro's Static Site Generation (SSG) step and adds unnecessary memory overhead, especially when building large static sites. 

📊 **Impact**: Faster post generation and sorting in the build step, reducing the garbage collection workload during `getStaticPaths()`.

🔬 **Measurement**: Use `pnpm run build` to see reduced memory and faster script parsing, with all posts remaining correctly sorted chronologically in both main archives and tag pagination.

---
*PR created automatically by Jules for task [16036921750976784485](https://jules.google.com/task/16036921750976784485) started by @PatilShreyas*