### PR TITLE
🎨 Palette: [UX improvement] Add aria-current to active navigation items

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -70,7 +70,11 @@ const isActive = (path: string) => {
         ]}
       >
         <li class="col-span-2">
-          <a href="/tags" class:list={{ "active-nav": isActive("/tags") }}>
+          <a
+            href="/tags"
+            class:list={{ "active-nav": isActive("/tags") }}
+            aria-current={isActive("/tags") ? "page" : undefined}
+          >
             Tags
           </a>
         </li>
@@ -90,6 +94,7 @@ const isActive = (path: string) => {
                 ]}
                 title="Archives"
                 aria-label="archives"
+                aria-current={isActive("/archives") ? "page" : undefined}
               >
                 <IconArchive class="hidden sm:inline-block" />
                 <span class="sm:sr-only">Archives</span>
@@ -106,6 +111,7 @@ const isActive = (path: string) => {
             ]}
             title="Search"
             aria-label="search"
+            aria-current={isActive("/search") ? "page" : undefined}
           >
             <IconSearch />
             <span class="sr-only">Search</span>


### PR DESCRIPTION
**💡 What:**
Added the `aria-current="page"` attribute dynamically to the main internal navigation links (Tags, Archives, Search) in `Header.astro`. This attribute is applied strictly when the current path matches the link's destination. 

**🎯 Why:**
Prior to this change, active navigation items were only visually distinct via the `active-nav` class. Adding the `aria-current` attribute ensures that screen reader users get the same spatial and state context regarding their current location within the navigation menu.

**📸 Before/After:**
- Before: `<a href="/tags" class="active-nav">Tags</a>`
- After: `<a href="/tags" class="active-nav" aria-current="page">Tags</a>`

**♿ Accessibility:**
Improves navigation state awareness for assistive technologies by explicitly communicating the current page, addressing a critical spatial navigation gap. Externally pointing links (like "About") are intentionally excluded to maintain semantic correctness, as they don't represent internal active views.

---
*PR created automatically by Jules for task [11802841913065075634](https://jules.google.com/task/11802841913065075634) started by @PatilShreyas*