### PR TITLE
🎨 Palette: Add aria-current="page" to active navigation links

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2026-06-09 - Descriptive Action Tooltips on Toggles
 **Learning:** For toggle buttons (like theme switchers), providing an `aria-label` or `title` that purely states the current state (e.g. "dark" or "auto") isn't fully informative to users hovering or using screen readers.
 **Action:** Use action-oriented labels like "Switch to dark theme" so the user knows exactly what will happen when they click it. Keep these attributes dynamic so they always reflect the next intended state.
+
+## 2026-06-10 - Accessible Navigation Active States
+**Learning:** While navigation links often use custom visual classes (like `.active-nav`) to denote the current page visually, screen readers rely on native attributes. Without `aria-current="page"`, assistive technologies cannot tell which link corresponds to the current page.
+**Action:** Always pair visual active states with `aria-current="page"` (using `aria-current={isActive ? 'page' : undefined}`) to ensure correct spatial context for all users. Do not apply this to external links.

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -70,7 +70,11 @@ const isActive = (path: string) => {
         ]}
       >
         <li class="col-span-2">
-          <a href="/tags" class:list={{ "active-nav": isActive("/tags") }}>
+          <a
+            href="/tags"
+            class:list={{ "active-nav": isActive("/tags") }}
+            aria-current={isActive("/tags") ? "page" : undefined}
+          >
             Tags
           </a>
         </li>
@@ -90,6 +94,7 @@ const isActive = (path: string) => {
                 ]}
                 title="Archives"
                 aria-label="archives"
+                aria-current={isActive("/archives") ? "page" : undefined}
               >
                 <IconArchive class="hidden sm:inline-block" />
                 <span class="sm:sr-only">Archives</span>
@@ -106,6 +111,7 @@ const isActive = (path: string) => {
             ]}
             title="Search"
             aria-label="search"
+            aria-current={isActive("/search") ? "page" : undefined}
           >
             <IconSearch />
             <span class="sr-only">Search</span>


### PR DESCRIPTION
**💡 What:** Added the `aria-current="page"` attribute to the main navigation links ('Tags', 'Archives', and 'Search') in the header when they are active.

**🎯 Why:** While the navigation links previously used a visual `.active-nav` class to denote the current page, this state was not being communicated to screen readers. This change ensures that assistive technologies can correctly identify which navigation item corresponds to the currently viewed page.

**📸 Before/After:**
- **Before:** Active link HTML was `<a href="/tags" class="active-nav">Tags</a>`
- **After:** Active link HTML is `<a href="/tags" class="active-nav" aria-current="page">Tags</a>`

**♿ Accessibility:** Greatly improves navigation context for screen reader users by programmatically identifying the current page within the navigation menu using the standard `aria-current` attribute.

---
*PR created automatically by Jules for task [2581430649434138287](https://jules.google.com/task/2581430649434138287) started by @PatilShreyas*