### PR TITLE
🎨 Palette: Add aria-current spatial context to header navigation links

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2026-06-09 - Descriptive Action Tooltips on Toggles
 **Learning:** For toggle buttons (like theme switchers), providing an `aria-label` or `title` that purely states the current state (e.g. "dark" or "auto") isn't fully informative to users hovering or using screen readers.
 **Action:** Use action-oriented labels like "Switch to dark theme" so the user knows exactly what will happen when they click it. Keep these attributes dynamic so they always reflect the next intended state.
+
+## 2026-06-25 - Spatial Context for Visual Active States in Navigation
+**Learning:** Visual active states (like CSS classes for the current page in a navigation menu) do not automatically convey their meaning to screen reader users. Simply styling the active page link creates a disconnect for accessibility. Setting the `aria-current="page"` attribute purely matches the visual representation of spatial context for screen readers. Furthermore, conditional attributes using `undefined` cleanly omit it when false, keeping the DOM clean. Lastly, external links should never receive this attribute since they leave the active internal scope.
+**Action:** Always accompany visual active state styles with an equivalent `aria-current="page"` attribute for internal navigation elements and omit it cleanly using `undefined` when inactive. Never apply this attribute to external links.

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -70,7 +70,11 @@ const isActive = (path: string) => {
         ]}
       >
         <li class="col-span-2">
-          <a href="/tags" class:list={{ "active-nav": isActive("/tags") }}>
+          <a
+            href="/tags"
+            class:list={{ "active-nav": isActive("/tags") }}
+            aria-current={isActive("/tags") ? "page" : undefined}
+          >
             Tags
           </a>
         </li>
@@ -90,6 +94,7 @@ const isActive = (path: string) => {
                 ]}
                 title="Archives"
                 aria-label="archives"
+                aria-current={isActive("/archives") ? "page" : undefined}
               >
                 <IconArchive class="hidden sm:inline-block" />
                 <span class="sm:sr-only">Archives</span>
@@ -106,6 +111,7 @@ const isActive = (path: string) => {
             ]}
             title="Search"
             aria-label="search"
+            aria-current={isActive("/search") ? "page" : undefined}
           >
             <IconSearch />
             <span class="sr-only">Search</span>


### PR DESCRIPTION
💡 What: Added `aria-current="page"` conditionally using `undefined` on Header navigation elements.
🎯 Why: Screen reader users did not receive spatial context indication of the active page that sighted users had via active visual styling.
📸 Before/After: Visual presentation stays precisely the same, DOM gets populated with `aria-current="page"` context exclusively for active links.
♿ Accessibility: Assistive technology will now properly recognize and announce the active page in internal site navigation.

---
*PR created automatically by Jules for task [10774652858225857432](https://jules.google.com/task/10774652858225857432) started by @PatilShreyas*