### PR TITLE
⚡ Bolt: Remove redundant Date allocations in sort paths

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2024-05-24 - Tag Deduplication Bottleneck
 **Learning:** The Astro static site generation can be slowed down by O(N^2) algorithms in data processing scripts, such as array deduplication using `filter` and `findIndex`, especially when the number of posts grows.
 **Action:** Use a `Map` or `Set` for O(N) deduplication when aggregating large collections of data during the build process to minimize build time.
+
+## 2024-05-24 - Redundant Date Re-allocation Bottleneck
+**Learning:** Zod schemas for Astro content collections already parse dates natively. Wrapping them in `new Date()` combined with unnecessary math operations like `Math.floor(... / 1000)` causes unnecessary object allocations and performance overhead, particularly O(NlogN) overhead during collection sorting.
+**Action:** Use `.getTime()` subtraction directly on Zod-parsed `Date` objects when calculating differences or sorting by timestamp to minimize overhead and prevent excessive garbage collection in hot loops.

--- a/src/pages/archives/index.astro
+++ b/src/pages/archives/index.astro
@@ -62,12 +62,8 @@ const months = [
                     {monthGroup
                       .sort(
                         (a, b) =>
-                          Math.floor(
-                            new Date(b.data.pubDatetime).getTime() / 1000
-                          ) -
-                          Math.floor(
-                            new Date(a.data.pubDatetime).getTime() / 1000
-                          )
+                          b.data.pubDatetime.getTime() -
+                          a.data.pubDatetime.getTime()
                       )
                       .map(data => (
                         <Card {...data} />

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -16,7 +16,7 @@ export async function GET() {
       link: getPath(id, filePath),
       title: data.title,
       description: data.description,
-      pubDate: new Date(data.modDatetime ?? data.pubDatetime),
+      pubDate: data.modDatetime ?? data.pubDatetime,
       customData: [
         `<author>${SITE.author}</author>`,
         ...data.tags.map(tag => `<category>${tag}</category>`),

--- a/src/utils/getSortedPosts.ts
+++ b/src/utils/getSortedPosts.ts
@@ -6,12 +6,8 @@ const getSortedPosts = (posts: CollectionEntry<"blog">[]) => {
     .filter(postFilter)
     .sort(
       (a, b) =>
-        Math.floor(
-          new Date(b.data.modDatetime ?? b.data.pubDatetime).getTime() / 1000
-        ) -
-        Math.floor(
-          new Date(a.data.modDatetime ?? a.data.pubDatetime).getTime() / 1000
-        )
+        (b.data.modDatetime ?? b.data.pubDatetime).getTime() -
+        (a.data.modDatetime ?? a.data.pubDatetime).getTime()
     );
 };
 

--- a/src/utils/postFilter.ts
+++ b/src/utils/postFilter.ts
@@ -3,8 +3,7 @@ import { SITE } from "@/config";
 
 const postFilter = ({ data }: CollectionEntry<"blog">) => {
   const isPublishTimePassed =
-    Date.now() >
-    new Date(data.pubDatetime).getTime() - SITE.scheduledPostMargin;
+    Date.now() > data.pubDatetime.getTime() - SITE.scheduledPostMargin;
   return !data.draft && (import.meta.env.DEV || isPublishTimePassed);
 };
 


### PR DESCRIPTION
💡 **What**: Removed redundant `new Date()` wrappers and unnecessary math operations (`Math.floor(... / 1000)`) when processing and sorting post dates. Replaced them with direct `getTime()` subtraction for O(1) comparison overhead inside O(NlogN) array sorting mechanisms.
🎯 **Why**: Astro's Zod schema natively parses `pubDatetime` and `modDatetime` frontmatter into JS `Date` objects. Re-wrapping them in another object inside array functions forces unnecessary memory allocations and garbage collections, especially as the number of posts grows, unnecessarily blocking the main thread during site generation.
📊 **Impact**: Reduces unnecessary object allocations and prevents excessive garbage collection during build processing arrays of large elements. Provides more precise sorting using true milliseconds. 
🔬 **Measurement**: Verified the site builds successfully and sorting functions operate identically with higher precision. Run `pnpm build` to verify functionality.

---
*PR created automatically by Jules for task [6966853537747904884](https://jules.google.com/task/6966853537747904884) started by @PatilShreyas*