### PR TITLE
🎨 Palette: [UX improvement] Accessible Navigation Links with aria-current

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2026-06-09 - Descriptive Action Tooltips on Toggles
 **Learning:** For toggle buttons (like theme switchers), providing an `aria-label` or `title` that purely states the current state (e.g. "dark" or "auto") isn't fully informative to users hovering or using screen readers.
 **Action:** Use action-oriented labels like "Switch to dark theme" so the user knows exactly what will happen when they click it. Keep these attributes dynamic so they always reflect the next intended state.
+
+## 2026-06-26 - Accessible Active Navigation States
+**Learning:** For accessible navigation, it is critical to always pair visual active states (e.g. active navigation link styling) with `aria-current="page"` to provide correct spatial context to screen reader users. However, in Astro components, conditionally rendering boolean attributes correctly requires setting the false state to `undefined` rather than `false`, so the attribute is cleanly omitted from the HTML (e.g. `aria-current={isActive ? 'page' : undefined}`). External links should not receive this attribute.
+**Action:** When creating or updating navigation menus, ensure active internal links use `aria-current="page"`, and leverage Astro's `undefined` pattern for conditionally omitting HTML attributes correctly.

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -70,7 +70,11 @@ const isActive = (path: string) => {
         ]}
       >
         <li class="col-span-2">
-          <a href="/tags" class:list={{ "active-nav": isActive("/tags") }}>
+          <a
+            href="/tags"
+            class:list={{ "active-nav": isActive("/tags") }}
+            aria-current={isActive("/tags") ? "page" : undefined}
+          >
             Tags
           </a>
         </li>
@@ -90,6 +94,7 @@ const isActive = (path: string) => {
                 ]}
                 title="Archives"
                 aria-label="archives"
+                aria-current={isActive("/archives") ? "page" : undefined}
               >
                 <IconArchive class="hidden sm:inline-block" />
                 <span class="sm:sr-only">Archives</span>
@@ -106,6 +111,7 @@ const isActive = (path: string) => {
             ]}
             title="Search"
             aria-label="search"
+            aria-current={isActive("/search") ? "page" : undefined}
           >
             <IconSearch />
             <span class="sr-only">Search</span>


### PR DESCRIPTION
💡 What: Added `aria-current="page"` dynamically to internal navigation links (Tags, Archives, Search) when they are active. Leveraged Astro's `undefined` fallback to ensure the attribute is completely omitted when not active. Intentionally did NOT add it to the external "About" link since it navigates away from the site.
🎯 Why: To provide critical spatial context to screen reader users about which navigation item corresponds to their current page view. This aligns screen reader feedback with the visual active state (styling).
📸 Before/After: No visual changes; purely structural HTML attribute addition for screen reader accessibility. Verified via playwright test evaluating the `aria-current` attribute.
♿ Accessibility: Ensures that active navigation links announce their "page" state correctly to assistive technologies.

---
*PR created automatically by Jules for task [8351631533789141619](https://jules.google.com/task/8351631533789141619) started by @PatilShreyas*