### PR TITLE
⚡ Bolt: Remove redundant `new Date()` wrappers around Astro content dates

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2024-05-24 - Tag Deduplication Bottleneck
 **Learning:** The Astro static site generation can be slowed down by O(N^2) algorithms in data processing scripts, such as array deduplication using `filter` and `findIndex`, especially when the number of posts grows.
 **Action:** Use a `Map` or `Set` for O(N) deduplication when aggregating large collections of data during the build process to minimize build time.
+
+## 2026-06-27 - Astro Collection Date Instantiation Anti-Pattern
+**Learning:** Zod schemas in Astro's `src/content.config.ts` natively parse fields like `pubDatetime` and `modDatetime` into `Date` objects. Wrapping these fields in `new Date()` again during sorting or rendering is redundant and causes unnecessary object instantiation and garbage collection.
+**Action:** Always use the parsed `Date` fields directly. Instead of `new Date(data.pubDatetime).getTime()`, use `data.pubDatetime.getTime()`.

--- a/src/pages/archives/index.astro
+++ b/src/pages/archives/index.astro
@@ -62,12 +62,8 @@ const months = [
                     {monthGroup
                       .sort(
                         (a, b) =>
-                          Math.floor(
-                            new Date(b.data.pubDatetime).getTime() / 1000
-                          ) -
-                          Math.floor(
-                            new Date(a.data.pubDatetime).getTime() / 1000
-                          )
+                          b.data.pubDatetime.getTime() -
+                          a.data.pubDatetime.getTime()
                       )
                       .map(data => (
                         <Card {...data} />

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -16,7 +16,7 @@ export async function GET() {
       link: getPath(id, filePath),
       title: data.title,
       description: data.description,
-      pubDate: new Date(data.modDatetime ?? data.pubDatetime),
+      pubDate: data.modDatetime ?? data.pubDatetime,
       customData: [
         `<author>${SITE.author}</author>`,
         ...data.tags.map(tag => `<category>${tag}</category>`),

--- a/src/utils/getSortedPosts.ts
+++ b/src/utils/getSortedPosts.ts
@@ -6,12 +6,8 @@ const getSortedPosts = (posts: CollectionEntry<"blog">[]) => {
     .filter(postFilter)
     .sort(
       (a, b) =>
-        Math.floor(
-          new Date(b.data.modDatetime ?? b.data.pubDatetime).getTime() / 1000
-        ) -
-        Math.floor(
-          new Date(a.data.modDatetime ?? a.data.pubDatetime).getTime() / 1000
-        )
+        (b.data.modDatetime ?? b.data.pubDatetime).getTime() -
+        (a.data.modDatetime ?? a.data.pubDatetime).getTime()
     );
 };
 

--- a/src/utils/postFilter.ts
+++ b/src/utils/postFilter.ts
@@ -3,8 +3,7 @@ import { SITE } from "@/config";
 
 const postFilter = ({ data }: CollectionEntry<"blog">) => {
   const isPublishTimePassed =
-    Date.now() >
-    new Date(data.pubDatetime).getTime() - SITE.scheduledPostMargin;
+    Date.now() > data.pubDatetime.getTime() - SITE.scheduledPostMargin;
   return !data.draft && (import.meta.env.DEV || isPublishTimePassed);
 };
 


### PR DESCRIPTION
💡 **What:** 
Removed redundant `new Date()` wrappers and `Math.floor` calculations around Astro content date fields (`pubDatetime` and `modDatetime`) across the codebase.

🎯 **Why:** 
Astro's content collection Zod schema parses these fields as native JavaScript `Date` objects during the build. Wrapping them in `new Date()` inside `.sort()` or `.filter()` functions repeatedly creates unnecessary object allocations and triggers unnecessary garbage collection, needlessly consuming CPU cycles and memory. The `Math.floor` calculation divided by 1000 was also mathematically unnecessary for comparing relative sort order. 

📊 **Impact:** 
- Reduces memory allocations during static site generation by eliminating redundant `Date` object creation within O(N log N) sorting algorithms and O(N) filtering algorithms. 
- Slightly speeds up build and sorting time.
- Cleans up and simplifies code readability.

🔬 **Measurement:** 
Run `pnpm build` to verify the site generates successfully without type errors or regressions. Look for unchanged or subtly improved build times.

---
*PR created automatically by Jules for task [8333662552434797868](https://jules.google.com/task/8333662552434797868) started by @PatilShreyas*