### PR TITLE
🎨 Palette: Add aria-current to active navigation links

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,6 @@
 ## 2026-06-09 - Descriptive Action Tooltips on Toggles
 **Learning:** For toggle buttons (like theme switchers), providing an `aria-label` or `title` that purely states the current state (e.g. "dark" or "auto") isn't fully informative to users hovering or using screen readers.
 **Action:** Use action-oriented labels like "Switch to dark theme" so the user knows exactly what will happen when they click it. Keep these attributes dynamic so they always reflect the next intended state.
+## 2026-06-27 - Accessible Active Navigation State
+**Learning:** In Astro components with dynamic navigation, purely visual styling (like `active-nav` CSS classes) isn't enough for screen readers. Pairing `aria-current={isActive ? 'page' : undefined}` ensures correct spatial context for visually impaired users without rendering empty HTML attributes when false.
+**Action:** Always verify that visually distinct active states in navigation menus are paired with semantic `aria-current="page"` attributes.

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -70,7 +70,11 @@ const isActive = (path: string) => {
         ]}
       >
         <li class="col-span-2">
-          <a href="/tags" class:list={{ "active-nav": isActive("/tags") }}>
+          <a
+            href="/tags"
+            class:list={{ "active-nav": isActive("/tags") }}
+            aria-current={isActive("/tags") ? "page" : undefined}
+          >
             Tags
           </a>
         </li>
@@ -90,6 +94,7 @@ const isActive = (path: string) => {
                 ]}
                 title="Archives"
                 aria-label="archives"
+                aria-current={isActive("/archives") ? "page" : undefined}
               >
                 <IconArchive class="hidden sm:inline-block" />
                 <span class="sm:sr-only">Archives</span>
@@ -106,6 +111,7 @@ const isActive = (path: string) => {
             ]}
             title="Search"
             aria-label="search"
+            aria-current={isActive("/search") ? "page" : undefined}
           >
             <IconSearch />
             <span class="sr-only">Search</span>


### PR DESCRIPTION
💡 What: Added `aria-current="page"` attribute to active internal navigation links in the header.
🎯 Why: To ensure screen reader users are properly informed of their current active page within the navigation menu.
📸 Before/After: Visual active states were present but lacked semantic meaning for assistive technologies.
♿ Accessibility: Improves navigation accessibility by pairing visual active state with the correct `aria-current="page"` attribute for screen readers.

---
*PR created automatically by Jules for task [5450069360718838417](https://jules.google.com/task/5450069360718838417) started by @PatilShreyas*